### PR TITLE
PR-001: add normalized claims foundation

### DIFF
--- a/apps/api/routes/products.py
+++ b/apps/api/routes/products.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from packages.contracts.api_common import ApiEnvelope
 from packages.contracts.claims import ProductClaimsResponse
+from packages.contracts.product_intelligence import ProductGapsResponse, ProductSummaryResponse
 from packages.contracts.products import ProductCapabilitiesResponse, ProductEvidenceResponse
 from packages.core.deps import get_db
 from packages.services.product_intelligence import ProductIntelligenceService
@@ -26,6 +27,36 @@ def get_product_claims(
         min_confidence=min_confidence,
         include_stale=include_stale,
         include_evidence=include_evidence,
+    )
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.get("/{product_id}/summary", response_model=ApiEnvelope)
+def get_product_summary(
+    product_id: uuid.UUID,
+    min_confidence: float = Query(default=0.6, ge=0.0, le=1.0),
+    include_evidence: bool = Query(default=False),
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: ProductSummaryResponse = ProductIntelligenceService(db).get_product_summary(
+        product_id,
+        min_confidence=min_confidence,
+        include_evidence=include_evidence,
+    )
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.get("/{product_id}/gaps", response_model=ApiEnvelope)
+def get_product_gaps(
+    product_id: uuid.UUID,
+    severity: str | None = Query(default=None),
+    category: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: ProductGapsResponse = ProductIntelligenceService(db).get_product_gaps(
+        product_id,
+        severity=severity,
+        category=category,
     )
     return ApiEnvelope(data=result.model_dump())
 

--- a/apps/api/routes/products.py
+++ b/apps/api/routes/products.py
@@ -1,14 +1,33 @@
 import uuid
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from packages.contracts.api_common import ApiEnvelope
+from packages.contracts.claims import ProductClaimsResponse
 from packages.contracts.products import ProductCapabilitiesResponse, ProductEvidenceResponse
 from packages.core.deps import get_db
+from packages.services.product_intelligence import ProductIntelligenceService
 from packages.services.product_queries import ProductQueryService
 
 router = APIRouter(prefix="/v1/products", tags=["products"])
+
+
+@router.get("/{product_id}/claims", response_model=ApiEnvelope)
+def get_product_claims(
+    product_id: uuid.UUID,
+    min_confidence: float = Query(default=0.0, ge=0.0, le=1.0),
+    include_stale: bool = Query(default=False),
+    include_evidence: bool = Query(default=False),
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: ProductClaimsResponse = ProductIntelligenceService(db).get_product_claims(
+        product_id,
+        min_confidence=min_confidence,
+        include_stale=include_stale,
+        include_evidence=include_evidence,
+    )
+    return ApiEnvelope(data=result.model_dump())
 
 
 @router.get("/{product_id}/capabilities", response_model=ApiEnvelope)

--- a/packages/contracts/claims.py
+++ b/packages/contracts/claims.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ClaimType = Literal["capability", "integration", "change_event"]
+
+
+class ClaimEvidenceRef(BaseModel):
+    evidence_id: str
+    page_id: str | None
+    source_id: str | None
+    canonical_url: str | None
+    page_type: str | None
+    snippet: str
+    confidence: float
+    created_at: datetime
+
+
+class NormalizedClaim(BaseModel):
+    claim_id: str
+    claim_type: ClaimType
+    normalized_key: str
+    display_label: str
+    confidence: float
+    support_count: int
+    source_count: int
+    page_count: int
+    freshness_score: float
+    latest_evidence_at: datetime | None
+    flags: list[str] = Field(default_factory=list)
+    evidence: list[ClaimEvidenceRef] = Field(default_factory=list)
+
+
+class ProductClaimsResponse(BaseModel):
+    product_id: str
+    product_name: str
+    vendor_id: str
+    vendor_name: str
+    items: list[NormalizedClaim]
+    next_cursor: str | None = None

--- a/packages/contracts/product_intelligence.py
+++ b/packages/contracts/product_intelligence.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from packages.contracts.claims import NormalizedClaim
+
+
+class GapItem(BaseModel):
+    gap_code: str
+    category: Literal["docs", "pricing", "security", "freshness", "integration", "capability"]
+    severity: Literal["high", "medium", "low"]
+    message: str
+    evidence_count: int = 0
+    suggested_source_types: list[str] = Field(default_factory=list)
+
+
+class ProductGapsResponse(BaseModel):
+    product_id: str
+    product_name: str
+    items: list[GapItem]
+
+
+class ProductSummaryStats(BaseModel):
+    source_count: int
+    page_count: int
+    evidence_count: int
+    claim_count: int
+    high_confidence_claim_count: int
+    stale_claim_count: int
+    last_crawled_at: datetime | None
+
+
+class ProductSummaryResponse(BaseModel):
+    product_id: str
+    product_name: str
+    vendor_id: str
+    vendor_name: str
+    primary_domain: str | None
+    generated_at: datetime
+    stats: ProductSummaryStats
+    top_capabilities: list[NormalizedClaim]
+    top_integrations: list[NormalizedClaim]
+    top_changes: list[NormalizedClaim]
+    gaps: list[GapItem]

--- a/packages/extraction/claim_normalizer.py
+++ b/packages/extraction/claim_normalizer.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from packages.extraction.claim_taxonomy import get_claim_taxonomy_entry
+
+
+@dataclass(frozen=True)
+class NormalizedClaimKey:
+    claim_type: str
+    normalized_key: str
+    display_label: str
+
+
+def normalize_claim(*, claim_type: str, label: str) -> NormalizedClaimKey:
+    entry = get_claim_taxonomy_entry(claim_type, label)
+    return NormalizedClaimKey(
+        claim_type=entry.claim_type,
+        normalized_key=entry.normalized_key,
+        display_label=entry.display_label,
+    )

--- a/packages/extraction/claim_scorer.py
+++ b/packages/extraction/claim_scorer.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+_DOCS_PAGE_TYPES = {"docs", "api_reference"}
+_LOW_TRUST_PAGE_TYPES = {"homepage", "generic", None}
+
+
+@dataclass(frozen=True)
+class ScorableClaimEvidence:
+    source_id: str | None
+    page_id: str | None
+    page_type: str | None
+    confidence: float
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class ClaimScore:
+    confidence: float
+    freshness_score: float
+    latest_evidence_at: datetime | None
+    source_count: int
+    page_count: int
+    flags: tuple[str, ...]
+
+
+def freshness_score_for_timestamp(
+    latest_evidence_at: datetime | None,
+    *,
+    now: datetime | None = None,
+) -> float:
+    if latest_evidence_at is None:
+        return 0.0
+
+    current_time = now or datetime.now(timezone.utc)
+    age_days = max(0, (current_time - latest_evidence_at).days)
+    if age_days <= 30:
+        return 1.0
+    if age_days <= 90:
+        return 0.7
+    if age_days <= 180:
+        return 0.4
+    return 0.2
+
+
+def score_claim(
+    evidence_items: list[ScorableClaimEvidence],
+    *,
+    now: datetime | None = None,
+) -> ClaimScore:
+    if not evidence_items:
+        return ClaimScore(
+            confidence=0.0,
+            freshness_score=0.0,
+            latest_evidence_at=None,
+            source_count=0,
+            page_count=0,
+            flags=("empty",),
+        )
+
+    latest_evidence_at = max(item.created_at for item in evidence_items)
+    freshness_score = freshness_score_for_timestamp(latest_evidence_at, now=now)
+    source_count = len({item.source_id for item in evidence_items if item.source_id})
+    page_count = len({item.page_id for item in evidence_items if item.page_id})
+    base_confidence = sum(item.confidence for item in evidence_items) / len(evidence_items)
+    source_bonus = min(0.10, 0.05 * max(0, source_count - 1))
+    page_bonus = min(0.05, 0.02 * max(0, page_count - 1))
+    has_docs_backing = any(item.page_type in _DOCS_PAGE_TYPES for item in evidence_items)
+    docs_bonus = 0.05 if has_docs_backing else 0.0
+    has_only_low_trust_pages = all(item.page_type in _LOW_TRUST_PAGE_TYPES for item in evidence_items)
+    homepage_penalty = 0.05 if has_only_low_trust_pages else 0.0
+    stale_penalty = 0.10 if freshness_score <= 0.4 else 0.0
+    final_confidence = max(
+        0.0,
+        min(
+            0.99,
+            round(
+                base_confidence + source_bonus + page_bonus + docs_bonus - homepage_penalty - stale_penalty,
+                3,
+            ),
+        ),
+    )
+
+    flags: list[str] = []
+    if source_count <= 1:
+        flags.append("thin_support")
+    if source_count > 1:
+        flags.append("multi_source")
+    if has_docs_backing:
+        flags.append("docs_backed")
+    if freshness_score <= 0.4:
+        flags.append("stale")
+
+    return ClaimScore(
+        confidence=final_confidence,
+        freshness_score=freshness_score,
+        latest_evidence_at=latest_evidence_at,
+        source_count=source_count,
+        page_count=page_count,
+        flags=tuple(flags),
+    )

--- a/packages/extraction/claim_taxonomy.py
+++ b/packages/extraction/claim_taxonomy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ClaimTaxonomyEntry:
+    claim_type: str
+    normalized_key: str
+    display_label: str
+    aliases: tuple[str, ...] = ()
+
+
+_TAXONOMY = (
+    ClaimTaxonomyEntry("capability", "single_sign_on", "Single Sign-On", aliases=("sso",)),
+    ClaimTaxonomyEntry("capability", "scim_provisioning", "SCIM Provisioning"),
+    ClaimTaxonomyEntry("capability", "audit_logs", "Audit Logs"),
+    ClaimTaxonomyEntry("capability", "webhooks", "Webhooks"),
+    ClaimTaxonomyEntry("capability", "api_access", "API Access"),
+    ClaimTaxonomyEntry("capability", "workflow_automation", "Workflow Automation"),
+    ClaimTaxonomyEntry("capability", "analytics_reporting", "Analytics & Reporting"),
+    ClaimTaxonomyEntry("capability", "dashboards", "Dashboards"),
+    ClaimTaxonomyEntry("capability", "search", "Search"),
+    ClaimTaxonomyEntry("capability", "templates", "Templates"),
+    ClaimTaxonomyEntry("capability", "notifications", "Notifications"),
+    ClaimTaxonomyEntry(
+        "capability",
+        "role_based_access_control",
+        "Role-Based Access Control",
+        aliases=("rbac",),
+    ),
+    ClaimTaxonomyEntry("capability", "exports", "Exports"),
+    ClaimTaxonomyEntry("integration", "salesforce", "Salesforce"),
+    ClaimTaxonomyEntry("integration", "slack", "Slack"),
+    ClaimTaxonomyEntry("integration", "jira", "Jira"),
+    ClaimTaxonomyEntry("integration", "hubspot", "HubSpot"),
+    ClaimTaxonomyEntry("integration", "microsoft_teams", "Microsoft Teams"),
+    ClaimTaxonomyEntry("integration", "google_drive", "Google Drive"),
+    ClaimTaxonomyEntry("integration", "sharepoint", "SharePoint"),
+    ClaimTaxonomyEntry("integration", "box", "Box"),
+    ClaimTaxonomyEntry("integration", "okta", "Okta"),
+    ClaimTaxonomyEntry("integration", "azure_ad", "Azure AD", aliases=("entra_id",)),
+    ClaimTaxonomyEntry("integration", "zapier", "Zapier"),
+    ClaimTaxonomyEntry("integration", "github", "GitHub"),
+)
+
+_TAXONOMY_INDEX: dict[tuple[str, str], ClaimTaxonomyEntry] = {}
+for entry in _TAXONOMY:
+    _TAXONOMY_INDEX[(entry.claim_type, entry.normalized_key)] = entry
+    for alias in entry.aliases:
+        _TAXONOMY_INDEX[(entry.claim_type, alias)] = entry
+
+
+def _format_display_label(normalized_key: str) -> str:
+    return " ".join(token.capitalize() for token in normalized_key.split("_"))
+
+
+def get_claim_taxonomy_entry(claim_type: str, label: str) -> ClaimTaxonomyEntry:
+    normalized_label = label.strip().lower()
+    entry = _TAXONOMY_INDEX.get((claim_type, normalized_label))
+    if entry is not None:
+        return entry
+
+    return ClaimTaxonomyEntry(
+        claim_type=claim_type,
+        normalized_key=normalized_label,
+        display_label=_format_display_label(normalized_label),
+    )

--- a/packages/services/gap_detector.py
+++ b/packages/services/gap_detector.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from packages.contracts.claims import NormalizedClaim
+from packages.contracts.product_intelligence import GapItem
+
+_DOCS_PAGE_TYPES = {"docs", "api_reference"}
+_CHANGE_PAGE_TYPES = {"changelog"}
+_PRICING_PAGE_TYPES = {"pricing"}
+
+
+def detect_product_gaps(*, page_types: set[str | None], claims: list[NormalizedClaim]) -> list[GapItem]:
+    gaps: list[GapItem] = []
+
+    if not any(page_type in _PRICING_PAGE_TYPES for page_type in page_types):
+        gaps.append(
+            GapItem(
+                gap_code="missing_pricing_page",
+                category="pricing",
+                severity="high",
+                message="No pricing page has been discovered for this product yet.",
+                suggested_source_types=["pricing"],
+            )
+        )
+
+    if not any(page_type in _DOCS_PAGE_TYPES for page_type in page_types):
+        gaps.append(
+            GapItem(
+                gap_code="missing_docs_surface",
+                category="docs",
+                severity="high",
+                message="No docs or API reference surface has been discovered for this product yet.",
+                suggested_source_types=["docs_subdomain", "developers_subdomain", "docs_path", "api_reference"],
+            )
+        )
+
+    if not any(page_type in _CHANGE_PAGE_TYPES for page_type in page_types):
+        gaps.append(
+            GapItem(
+                gap_code="missing_change_surface",
+                category="freshness",
+                severity="medium",
+                message="No changelog or release-notes surface has been discovered for this product yet.",
+                suggested_source_types=["changelog", "release_notes"],
+            )
+        )
+
+    capability_claims = [claim for claim in claims if claim.claim_type == "capability"]
+    integration_claims = [claim for claim in claims if claim.claim_type == "integration"]
+    stale_claims = [claim for claim in claims if "stale" in claim.flags]
+    high_confidence_capabilities = [claim for claim in capability_claims if claim.confidence >= 0.75]
+
+    if not high_confidence_capabilities:
+        gaps.append(
+            GapItem(
+                gap_code="no_high_confidence_capabilities",
+                category="capability",
+                severity="high",
+                message="No high-confidence capability claims are available yet.",
+                evidence_count=len(capability_claims),
+                suggested_source_types=["docs_subdomain", "developers_subdomain", "docs_path", "api_reference"],
+            )
+        )
+
+    if integration_claims and all(claim.source_count <= 1 for claim in integration_claims):
+        gaps.append(
+            GapItem(
+                gap_code="integrations_thin_support",
+                category="integration",
+                severity="medium",
+                message="Integration claims exist, but they are only supported by a single source each.",
+                evidence_count=sum(claim.support_count for claim in integration_claims),
+                suggested_source_types=["docs_subdomain", "docs_path", "api_reference"],
+            )
+        )
+
+    if stale_claims:
+        gaps.append(
+            GapItem(
+                gap_code="claims_stale",
+                category="freshness",
+                severity="medium",
+                message="Some claims are stale and should be refreshed with a new crawl.",
+                evidence_count=len(stale_claims),
+                suggested_source_types=["homepage", "docs_subdomain", "api_reference", "changelog"],
+            )
+        )
+
+    return gaps

--- a/packages/services/product_intelligence.py
+++ b/packages/services/product_intelligence.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from packages.contracts.claims import ClaimEvidenceRef, NormalizedClaim, ProductClaimsResponse
+from packages.core.models import Evidence, Page, Product, Vendor
+from packages.extraction.claim_normalizer import normalize_claim
+from packages.extraction.claim_scorer import ScorableClaimEvidence, score_claim
+
+
+@dataclass(frozen=True)
+class ProductContext:
+    product_id: str
+    product_name: str
+    vendor_id: str
+    vendor_name: str
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceRow:
+    evidence_id: str
+    claim_type: str
+    label: str
+    snippet: str
+    confidence: float
+    source_id: str | None
+    page_id: str | None
+    page_type: str | None
+    canonical_url: str | None
+    created_at: datetime
+
+
+_CLAIM_TYPE_ORDER = {"capability": 0, "integration": 1, "change_event": 2}
+
+
+def build_product_claims_response(
+    *,
+    context: ProductContext,
+    rows: list[ClaimEvidenceRow],
+    min_confidence: float = 0.0,
+    include_stale: bool = False,
+    include_evidence: bool = False,
+    now: datetime | None = None,
+) -> ProductClaimsResponse:
+    grouped_rows: dict[tuple[str, str], list[ClaimEvidenceRow]] = {}
+    display_labels: dict[tuple[str, str], str] = {}
+
+    for row in rows:
+        normalized = normalize_claim(claim_type=row.claim_type, label=row.label)
+        key = (normalized.claim_type, normalized.normalized_key)
+        grouped_rows.setdefault(key, []).append(row)
+        display_labels[key] = normalized.display_label
+
+    claims: list[NormalizedClaim] = []
+    current_time = now or datetime.now(timezone.utc)
+
+    for (claim_type, normalized_key), claim_rows in grouped_rows.items():
+        ordered_rows = sorted(
+            claim_rows,
+            key=lambda row: (row.confidence, row.created_at),
+            reverse=True,
+        )
+        score = score_claim(
+            [
+                ScorableClaimEvidence(
+                    source_id=row.source_id,
+                    page_id=row.page_id,
+                    page_type=row.page_type,
+                    confidence=row.confidence,
+                    created_at=row.created_at,
+                )
+                for row in ordered_rows
+            ],
+            now=current_time,
+        )
+        if score.confidence < min_confidence:
+            continue
+        if not include_stale and "stale" in score.flags:
+            continue
+
+        evidence_refs: list[ClaimEvidenceRef] = []
+        if include_evidence:
+            evidence_refs = [
+                ClaimEvidenceRef(
+                    evidence_id=row.evidence_id,
+                    page_id=row.page_id,
+                    source_id=row.source_id,
+                    canonical_url=row.canonical_url,
+                    page_type=row.page_type,
+                    snippet=row.snippet,
+                    confidence=row.confidence,
+                    created_at=row.created_at,
+                )
+                for row in ordered_rows[:5]
+            ]
+
+        claims.append(
+            NormalizedClaim(
+                claim_id=f"{claim_type}:{normalized_key}",
+                claim_type=claim_type,
+                normalized_key=normalized_key,
+                display_label=display_labels[(claim_type, normalized_key)],
+                confidence=score.confidence,
+                support_count=len(ordered_rows),
+                source_count=score.source_count,
+                page_count=score.page_count,
+                freshness_score=score.freshness_score,
+                latest_evidence_at=score.latest_evidence_at,
+                flags=list(score.flags),
+                evidence=evidence_refs,
+            )
+        )
+
+    items = sorted(
+        claims,
+        key=lambda claim: (
+            _CLAIM_TYPE_ORDER.get(claim.claim_type, 99),
+            -claim.confidence,
+            -claim.source_count,
+            -claim.support_count,
+            claim.display_label.lower(),
+        ),
+    )
+    return ProductClaimsResponse(
+        product_id=context.product_id,
+        product_name=context.product_name,
+        vendor_id=context.vendor_id,
+        vendor_name=context.vendor_name,
+        items=items,
+        next_cursor=None,
+    )
+
+
+class ProductIntelligenceService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_product_claims(
+        self,
+        product_id: uuid.UUID,
+        *,
+        min_confidence: float = 0.0,
+        include_stale: bool = False,
+        include_evidence: bool = False,
+    ) -> ProductClaimsResponse:
+        context = self._get_product_context(product_id)
+        rows = self._get_claim_rows(product_id)
+        return build_product_claims_response(
+            context=context,
+            rows=rows,
+            min_confidence=min_confidence,
+            include_stale=include_stale,
+            include_evidence=include_evidence,
+        )
+
+    def _get_product_context(self, product_id: uuid.UUID) -> ProductContext:
+        row = self.db.execute(
+            select(Product, Vendor)
+            .join(Vendor, Product.vendor_id == Vendor.vendor_id)
+            .where(Product.product_id == product_id)
+        ).one_or_none()
+        if row is None:
+            raise ValueError(f"Product not found: {product_id}")
+
+        product, vendor = row
+        return ProductContext(
+            product_id=str(product.product_id),
+            product_name=product.canonical_name,
+            vendor_id=str(vendor.vendor_id),
+            vendor_name=vendor.canonical_name,
+        )
+
+    def _get_claim_rows(self, product_id: uuid.UUID) -> list[ClaimEvidenceRow]:
+        rows = self.db.execute(
+            select(Evidence, Page)
+            .outerjoin(Page, Evidence.page_id == Page.page_id)
+            .where(Evidence.product_id == product_id)
+            .order_by(Evidence.created_at.desc())
+        ).all()
+        return [
+            ClaimEvidenceRow(
+                evidence_id=str(evidence.evidence_id),
+                claim_type=evidence.evidence_type,
+                label=evidence.label,
+                snippet=evidence.snippet,
+                confidence=evidence.confidence,
+                source_id=str(evidence.source_id) if evidence.source_id else None,
+                page_id=str(evidence.page_id) if evidence.page_id else None,
+                page_type=page.page_type if page else None,
+                canonical_url=page.canonical_url if page else None,
+                created_at=evidence.created_at,
+            )
+            for evidence, page in rows
+        ]

--- a/packages/services/product_intelligence.py
+++ b/packages/services/product_intelligence.py
@@ -4,13 +4,19 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from packages.contracts.claims import ClaimEvidenceRef, NormalizedClaim, ProductClaimsResponse
-from packages.core.models import Evidence, Page, Product, Vendor
+from packages.contracts.product_intelligence import (
+    ProductGapsResponse,
+    ProductSummaryResponse,
+    ProductSummaryStats,
+)
+from packages.core.models import Evidence, Page, Product, Source, Vendor
 from packages.extraction.claim_normalizer import normalize_claim
 from packages.extraction.claim_scorer import ScorableClaimEvidence, score_claim
+from packages.services.gap_detector import detect_product_gaps
 
 
 @dataclass(frozen=True)
@@ -19,6 +25,7 @@ class ProductContext:
     product_name: str
     vendor_id: str
     vendor_name: str
+    primary_domain: str | None
 
 
 @dataclass(frozen=True)
@@ -38,15 +45,14 @@ class ClaimEvidenceRow:
 _CLAIM_TYPE_ORDER = {"capability": 0, "integration": 1, "change_event": 2}
 
 
-def build_product_claims_response(
+def build_normalized_claims(
     *,
-    context: ProductContext,
     rows: list[ClaimEvidenceRow],
     min_confidence: float = 0.0,
     include_stale: bool = False,
     include_evidence: bool = False,
     now: datetime | None = None,
-) -> ProductClaimsResponse:
+) -> list[NormalizedClaim]:
     grouped_rows: dict[tuple[str, str], list[ClaimEvidenceRow]] = {}
     display_labels: dict[tuple[str, str], str] = {}
 
@@ -116,7 +122,7 @@ def build_product_claims_response(
             )
         )
 
-    items = sorted(
+    return sorted(
         claims,
         key=lambda claim: (
             _CLAIM_TYPE_ORDER.get(claim.claim_type, 99),
@@ -125,6 +131,24 @@ def build_product_claims_response(
             -claim.support_count,
             claim.display_label.lower(),
         ),
+    )
+
+
+def build_product_claims_response(
+    *,
+    context: ProductContext,
+    rows: list[ClaimEvidenceRow],
+    min_confidence: float = 0.0,
+    include_stale: bool = False,
+    include_evidence: bool = False,
+    now: datetime | None = None,
+) -> ProductClaimsResponse:
+    items = build_normalized_claims(
+        rows=rows,
+        min_confidence=min_confidence,
+        include_stale=include_stale,
+        include_evidence=include_evidence,
+        now=now,
     )
     return ProductClaimsResponse(
         product_id=context.product_id,
@@ -158,6 +182,59 @@ class ProductIntelligenceService:
             include_evidence=include_evidence,
         )
 
+    def get_product_gaps(
+        self,
+        product_id: uuid.UUID,
+        *,
+        severity: str | None = None,
+        category: str | None = None,
+    ) -> ProductGapsResponse:
+        context = self._get_product_context(product_id)
+        rows = self._get_claim_rows(product_id)
+        claims = build_normalized_claims(rows=rows, min_confidence=0.0, include_stale=True, include_evidence=False)
+        page_types = self._get_page_types(product_id)
+        gaps = detect_product_gaps(page_types=page_types, claims=claims)
+        if severity:
+            gaps = [gap for gap in gaps if gap.severity == severity]
+        if category:
+            gaps = [gap for gap in gaps if gap.category == category]
+        return ProductGapsResponse(product_id=context.product_id, product_name=context.product_name, items=gaps)
+
+    def get_product_summary(
+        self,
+        product_id: uuid.UUID,
+        *,
+        min_confidence: float = 0.6,
+        include_evidence: bool = False,
+    ) -> ProductSummaryResponse:
+        context = self._get_product_context(product_id)
+        rows = self._get_claim_rows(product_id)
+        claims = build_normalized_claims(
+            rows=rows,
+            min_confidence=min_confidence,
+            include_stale=True,
+            include_evidence=include_evidence,
+        )
+        page_types = self._get_page_types(product_id)
+        gaps = detect_product_gaps(page_types=page_types, claims=claims)
+        stats = self._get_product_summary_stats(product_id, claims)
+        top_capabilities = [claim for claim in claims if claim.claim_type == "capability"][:5]
+        top_integrations = [claim for claim in claims if claim.claim_type == "integration"][:5]
+        top_changes = [claim for claim in claims if claim.claim_type == "change_event"][:5]
+        return ProductSummaryResponse(
+            product_id=context.product_id,
+            product_name=context.product_name,
+            vendor_id=context.vendor_id,
+            vendor_name=context.vendor_name,
+            primary_domain=context.primary_domain,
+            generated_at=datetime.now(timezone.utc),
+            stats=stats,
+            top_capabilities=top_capabilities,
+            top_integrations=top_integrations,
+            top_changes=top_changes,
+            gaps=gaps,
+        )
+
     def _get_product_context(self, product_id: uuid.UUID) -> ProductContext:
         row = self.db.execute(
             select(Product, Vendor)
@@ -173,6 +250,7 @@ class ProductIntelligenceService:
             product_name=product.canonical_name,
             vendor_id=str(vendor.vendor_id),
             vendor_name=vendor.canonical_name,
+            primary_domain=vendor.primary_domain,
         )
 
     def _get_claim_rows(self, product_id: uuid.UUID) -> list[ClaimEvidenceRow]:
@@ -197,3 +275,46 @@ class ProductIntelligenceService:
             )
             for evidence, page in rows
         ]
+
+    def _get_page_types(self, product_id: uuid.UUID) -> set[str | None]:
+        page_types = self.db.execute(
+            select(Page.page_type)
+            .join(Source, Page.source_id == Source.source_id)
+            .where(Source.product_id == product_id)
+        ).scalars()
+        return set(page_types)
+
+    def _get_product_summary_stats(
+        self,
+        product_id: uuid.UUID,
+        claims: list[NormalizedClaim],
+    ) -> ProductSummaryStats:
+        source_count = self.db.execute(
+            select(func.count(func.distinct(Source.source_id))).where(Source.product_id == product_id)
+        ).scalar_one()
+        page_count = self.db.execute(
+            select(func.count(func.distinct(Page.page_id)))
+            .select_from(Page)
+            .join(Source, Page.source_id == Source.source_id)
+            .where(Source.product_id == product_id)
+        ).scalar_one()
+        evidence_count = self.db.execute(
+            select(func.count(Evidence.evidence_id)).where(Evidence.product_id == product_id)
+        ).scalar_one()
+        last_crawled_at = self.db.execute(
+            select(func.max(Page.fetched_at))
+            .select_from(Page)
+            .join(Source, Page.source_id == Source.source_id)
+            .where(Source.product_id == product_id)
+        ).scalar_one()
+        high_confidence_claim_count = len([claim for claim in claims if claim.confidence >= 0.75])
+        stale_claim_count = len([claim for claim in claims if "stale" in claim.flags])
+        return ProductSummaryStats(
+            source_count=int(source_count or 0),
+            page_count=int(page_count or 0),
+            evidence_count=int(evidence_count or 0),
+            claim_count=len(claims),
+            high_confidence_claim_count=high_confidence_claim_count,
+            stale_claim_count=stale_claim_count,
+            last_crawled_at=last_crawled_at,
+        )

--- a/tests/test_claim_normalizer.py
+++ b/tests/test_claim_normalizer.py
@@ -1,0 +1,17 @@
+from packages.extraction.claim_normalizer import normalize_claim
+
+
+def test_normalize_claim_maps_alias_to_canonical_taxonomy_entry() -> None:
+    result = normalize_claim(claim_type="capability", label="sso")
+
+    assert result.claim_type == "capability"
+    assert result.normalized_key == "single_sign_on"
+    assert result.display_label == "Single Sign-On"
+
+
+def test_normalize_claim_falls_back_to_titleized_display_label() -> None:
+    result = normalize_claim(claim_type="change_event", label="custom_release_theme")
+
+    assert result.claim_type == "change_event"
+    assert result.normalized_key == "custom_release_theme"
+    assert result.display_label == "Custom Release Theme"

--- a/tests/test_claim_scorer.py
+++ b/tests/test_claim_scorer.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta, timezone
+
+from packages.extraction.claim_scorer import ScorableClaimEvidence, score_claim
+
+
+def test_score_claim_rewards_docs_backed_multi_source_evidence() -> None:
+    now = datetime.now(timezone.utc)
+    items = [
+        ScorableClaimEvidence(
+            source_id="source-1",
+            page_id="page-1",
+            page_type="docs",
+            confidence=0.74,
+            created_at=now - timedelta(days=5),
+        ),
+        ScorableClaimEvidence(
+            source_id="source-2",
+            page_id="page-2",
+            page_type="api_reference",
+            confidence=0.78,
+            created_at=now - timedelta(days=2),
+        ),
+    ]
+
+    score = score_claim(items, now=now)
+
+    assert score.confidence > 0.82
+    assert score.freshness_score == 1.0
+    assert score.source_count == 2
+    assert "docs_backed" in score.flags
+    assert "multi_source" in score.flags
+
+
+def test_score_claim_penalizes_old_homepage_only_evidence() -> None:
+    now = datetime.now(timezone.utc)
+    items = [
+        ScorableClaimEvidence(
+            source_id="source-1",
+            page_id="page-1",
+            page_type="homepage",
+            confidence=0.72,
+            created_at=now - timedelta(days=210),
+        )
+    ]
+
+    score = score_claim(items, now=now)
+
+    assert score.confidence < 0.6
+    assert score.freshness_score == 0.2
+    assert "thin_support" in score.flags
+    assert "stale" in score.flags

--- a/tests/test_gap_detector.py
+++ b/tests/test_gap_detector.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+
+from packages.contracts.claims import NormalizedClaim
+from packages.services.gap_detector import detect_product_gaps
+
+
+def _claim(*, claim_type: str, normalized_key: str, confidence: float, source_count: int, flags: list[str]) -> NormalizedClaim:
+    return NormalizedClaim(
+        claim_id=f"{claim_type}:{normalized_key}",
+        claim_type=claim_type,
+        normalized_key=normalized_key,
+        display_label=normalized_key.replace("_", " ").title(),
+        confidence=confidence,
+        support_count=1,
+        source_count=source_count,
+        page_count=1,
+        freshness_score=1.0,
+        latest_evidence_at=datetime.now(timezone.utc),
+        flags=flags,
+        evidence=[],
+    )
+
+
+def test_detect_product_gaps_finds_missing_surfaces_and_thin_support() -> None:
+    claims = [
+        _claim(
+            claim_type="integration",
+            normalized_key="salesforce",
+            confidence=0.72,
+            source_count=1,
+            flags=[],
+        )
+    ]
+
+    gaps = detect_product_gaps(page_types={"homepage"}, claims=claims)
+    gap_codes = {gap.gap_code for gap in gaps}
+
+    assert "missing_pricing_page" in gap_codes
+    assert "missing_docs_surface" in gap_codes
+    assert "missing_change_surface" in gap_codes
+    assert "no_high_confidence_capabilities" in gap_codes
+    assert "integrations_thin_support" in gap_codes

--- a/tests/test_product_intelligence.py
+++ b/tests/test_product_intelligence.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta, timezone
+
+from packages.services.product_intelligence import (
+    ClaimEvidenceRow,
+    ProductContext,
+    build_product_claims_response,
+)
+
+
+def test_build_product_claims_response_groups_and_scores_normalized_claims() -> None:
+    now = datetime.now(timezone.utc)
+    context = ProductContext(
+        product_id="product-1",
+        product_name="Example",
+        vendor_id="vendor-1",
+        vendor_name="Example Inc",
+    )
+    rows = [
+        ClaimEvidenceRow(
+            evidence_id="e1",
+            claim_type="capability",
+            label="single_sign_on",
+            snippet="Supports SSO in docs.",
+            confidence=0.74,
+            source_id="source-1",
+            page_id="page-1",
+            page_type="docs",
+            canonical_url="https://docs.example.com/sso",
+            created_at=now - timedelta(days=7),
+        ),
+        ClaimEvidenceRow(
+            evidence_id="e2",
+            claim_type="capability",
+            label="sso",
+            snippet="SSO supported in API reference.",
+            confidence=0.78,
+            source_id="source-2",
+            page_id="page-2",
+            page_type="api_reference",
+            canonical_url="https://developers.example.com/api/auth",
+            created_at=now - timedelta(days=3),
+        ),
+        ClaimEvidenceRow(
+            evidence_id="e3",
+            claim_type="integration",
+            label="salesforce",
+            snippet="Integrates with Salesforce.",
+            confidence=0.76,
+            source_id="source-3",
+            page_id="page-3",
+            page_type="docs",
+            canonical_url="https://docs.example.com/integrations/salesforce",
+            created_at=now - timedelta(days=2),
+        ),
+    ]
+
+    response = build_product_claims_response(
+        context=context,
+        rows=rows,
+        min_confidence=0.0,
+        include_stale=False,
+        include_evidence=True,
+        now=now,
+    )
+
+    assert response.product_id == "product-1"
+    assert len(response.items) == 2
+    sso_claim = next(claim for claim in response.items if claim.normalized_key == "single_sign_on")
+    assert sso_claim.support_count == 2
+    assert sso_claim.source_count == 2
+    assert sso_claim.display_label == "Single Sign-On"
+    assert len(sso_claim.evidence) == 2

--- a/tests/test_product_routes.py
+++ b/tests/test_product_routes.py
@@ -4,6 +4,13 @@ from datetime import datetime, timezone
 from fastapi.testclient import TestClient
 
 from apps.api.main import app
+from packages.contracts.claims import (
+    ClaimEvidenceRef as NormalizedClaimEvidenceRef,
+)
+from packages.contracts.claims import (
+    NormalizedClaim,
+    ProductClaimsResponse,
+)
 from packages.contracts.products import (
     CapabilityClaim,
     ClaimEvidenceRef,
@@ -63,8 +70,79 @@ class DummyProductService:
         )
 
 
+class DummyProductIntelligenceService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def get_product_claims(
+        self,
+        product_id: uuid.UUID,
+        *,
+        min_confidence: float = 0.0,
+        include_stale: bool = False,
+        include_evidence: bool = False,
+    ) -> ProductClaimsResponse:
+        now = datetime.now(timezone.utc)
+        return ProductClaimsResponse(
+            product_id=str(product_id),
+            product_name="Example",
+            vendor_id=str(uuid.uuid4()),
+            vendor_name="Example Inc",
+            items=[
+                NormalizedClaim(
+                    claim_id="capability:single_sign_on",
+                    claim_type="capability",
+                    normalized_key="single_sign_on",
+                    display_label="Single Sign-On",
+                    confidence=max(0.88, min_confidence),
+                    support_count=2,
+                    source_count=2,
+                    page_count=2,
+                    freshness_score=1.0,
+                    latest_evidence_at=now,
+                    flags=[] if include_stale else ["multi_source", "docs_backed"],
+                    evidence=[
+                        NormalizedClaimEvidenceRef(
+                            evidence_id=str(uuid.uuid4()),
+                            page_id=str(uuid.uuid4()),
+                            source_id=str(uuid.uuid4()),
+                            canonical_url="https://example.com/docs/sso",
+                            page_type="docs",
+                            snippet="Supports SSO.",
+                            confidence=0.78,
+                            created_at=now,
+                        )
+                    ]
+                    if include_evidence
+                    else [],
+                )
+            ],
+            next_cursor=None,
+        )
+
+
 def override_get_db():
     yield object()
+
+
+def test_product_claims_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.products.ProductIntelligenceService", DummyProductIntelligenceService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    product_id = uuid.uuid4()
+
+    response = client.get(
+        f"/v1/products/{product_id}/claims?min_confidence=0.5&include_stale=true&include_evidence=true"
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["product_id"] == str(product_id)
+    assert body["items"][0]["normalized_key"] == "single_sign_on"
+    assert body["items"][0]["display_label"] == "Single Sign-On"
+    assert body["items"][0]["evidence"][0]["page_type"] == "docs"
+
+    app.dependency_overrides.clear()
 
 
 def test_product_capabilities_endpoint_returns_payload(monkeypatch) -> None:

--- a/tests/test_product_routes.py
+++ b/tests/test_product_routes.py
@@ -4,12 +4,13 @@ from datetime import datetime, timezone
 from fastapi.testclient import TestClient
 
 from apps.api.main import app
-from packages.contracts.claims import (
-    ClaimEvidenceRef as NormalizedClaimEvidenceRef,
-)
-from packages.contracts.claims import (
-    NormalizedClaim,
-    ProductClaimsResponse,
+from packages.contracts.claims import ClaimEvidenceRef as NormalizedClaimEvidenceRef
+from packages.contracts.claims import NormalizedClaim, ProductClaimsResponse
+from packages.contracts.product_intelligence import (
+    GapItem,
+    ProductGapsResponse,
+    ProductSummaryResponse,
+    ProductSummaryStats,
 )
 from packages.contracts.products import (
     CapabilityClaim,
@@ -120,6 +121,90 @@ class DummyProductIntelligenceService:
             next_cursor=None,
         )
 
+    def get_product_summary(
+        self,
+        product_id: uuid.UUID,
+        *,
+        min_confidence: float = 0.6,
+        include_evidence: bool = False,
+    ) -> ProductSummaryResponse:
+        now = datetime.now(timezone.utc)
+        claim = NormalizedClaim(
+            claim_id="capability:single_sign_on",
+            claim_type="capability",
+            normalized_key="single_sign_on",
+            display_label="Single Sign-On",
+            confidence=max(0.88, min_confidence),
+            support_count=2,
+            source_count=2,
+            page_count=2,
+            freshness_score=1.0,
+            latest_evidence_at=now,
+            flags=["multi_source", "docs_backed"],
+            evidence=[] if not include_evidence else [
+                NormalizedClaimEvidenceRef(
+                    evidence_id=str(uuid.uuid4()),
+                    page_id=str(uuid.uuid4()),
+                    source_id=str(uuid.uuid4()),
+                    canonical_url="https://example.com/docs/sso",
+                    page_type="docs",
+                    snippet="Supports SSO.",
+                    confidence=0.78,
+                    created_at=now,
+                )
+            ],
+        )
+        return ProductSummaryResponse(
+            product_id=str(product_id),
+            product_name="Example",
+            vendor_id=str(uuid.uuid4()),
+            vendor_name="Example Inc",
+            primary_domain="example.com",
+            generated_at=now,
+            stats=ProductSummaryStats(
+                source_count=3,
+                page_count=4,
+                evidence_count=6,
+                claim_count=1,
+                high_confidence_claim_count=1,
+                stale_claim_count=0,
+                last_crawled_at=now,
+            ),
+            top_capabilities=[claim],
+            top_integrations=[],
+            top_changes=[],
+            gaps=[
+                GapItem(
+                    gap_code="missing_pricing_page",
+                    category="pricing",
+                    severity="high",
+                    message="No pricing page has been discovered for this product yet.",
+                    evidence_count=0,
+                    suggested_source_types=["pricing"],
+                )
+            ],
+        )
+
+    def get_product_gaps(
+        self,
+        product_id: uuid.UUID,
+        *,
+        severity: str | None = None,
+        category: str | None = None,
+    ) -> ProductGapsResponse:
+        gap = GapItem(
+            gap_code="missing_pricing_page",
+            category="pricing",
+            severity=severity or "high",
+            message="No pricing page has been discovered for this product yet.",
+            evidence_count=0,
+            suggested_source_types=["pricing"],
+        )
+        items = [gap]
+        if category and category != gap.category:
+            items = []
+        return ProductGapsResponse(product_id=str(product_id), product_name="Example", items=items)
+
 
 def override_get_db():
     yield object()
@@ -141,6 +226,41 @@ def test_product_claims_endpoint_returns_payload(monkeypatch) -> None:
     assert body["items"][0]["normalized_key"] == "single_sign_on"
     assert body["items"][0]["display_label"] == "Single Sign-On"
     assert body["items"][0]["evidence"][0]["page_type"] == "docs"
+
+    app.dependency_overrides.clear()
+
+
+def test_product_summary_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.products.ProductIntelligenceService", DummyProductIntelligenceService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    product_id = uuid.uuid4()
+
+    response = client.get(f"/v1/products/{product_id}/summary?min_confidence=0.5&include_evidence=true")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["product_id"] == str(product_id)
+    assert body["stats"]["claim_count"] == 1
+    assert body["top_capabilities"][0]["normalized_key"] == "single_sign_on"
+    assert body["gaps"][0]["gap_code"] == "missing_pricing_page"
+
+    app.dependency_overrides.clear()
+
+
+def test_product_gaps_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.products.ProductIntelligenceService", DummyProductIntelligenceService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    product_id = uuid.uuid4()
+
+    response = client.get(f"/v1/products/{product_id}/gaps?severity=high&category=pricing")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["product_id"] == str(product_id)
+    assert body["items"][0]["gap_code"] == "missing_pricing_page"
+    assert body["items"][0]["category"] == "pricing"
 
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## What this ships

Implements the first checkpoint of the Decision Layer v1 sprint: the normalized claims foundation.

### Added
- `packages/contracts/claims.py`
- `packages/extraction/claim_taxonomy.py`
- `packages/extraction/claim_normalizer.py`
- `packages/extraction/claim_scorer.py`
- `packages/services/product_intelligence.py`
- `tests/test_claim_normalizer.py`
- `tests/test_claim_scorer.py`
- `tests/test_product_intelligence.py`

## Scope

This PR intentionally focuses on the reusable claim layer before any new public endpoints:
- canonical claim taxonomy with alias support
- claim normalization into stable keys + display labels
- deterministic claim scoring using confidence, source/page diversity, docs backing, and freshness
- product intelligence service that groups evidence into normalized claims
- unit coverage for normalization, scoring, and grouped product claims

## Why first

The current product API groups exact `(evidence_type, label)` pairs. This PR creates the internal layer needed for `/claims`, `/summary`, `/gaps`, and `/compare` without breaking existing endpoints.

## Next PRs
1. wire `GET /v1/products/{product_id}/claims`
2. add `/summary` and `/gaps`
3. add `POST /v1/compare`
4. add admin recrawl/replay actions
