### PR TITLE
PR-004: add deterministic compare endpoint

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from apps.api.routes.admin import router as admin_router
+from apps.api.routes.compare import router as compare_router
 from apps.api.routes.products import router as products_router
 from apps.api.routes.vendors import router as vendors_router
 from packages.core.config import get_settings
@@ -14,6 +15,7 @@ app = FastAPI(
 app.include_router(vendors_router)
 app.include_router(admin_router)
 app.include_router(products_router)
+app.include_router(compare_router)
 
 
 @app.get("/healthz", tags=["system"])

--- a/apps/api/routes/compare.py
+++ b/apps/api/routes/compare.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from packages.contracts.api_common import ApiEnvelope
+from packages.contracts.compare import CompareRequest, CompareResponse
+from packages.core.deps import get_db
+from packages.services.compare_service import CompareService
+
+router = APIRouter(prefix="/v1", tags=["compare"])
+
+
+@router.post("/compare", response_model=ApiEnvelope)
+def compare_products(payload: CompareRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: CompareResponse = CompareService(db).compare_products(payload)
+    return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/compare.py
+++ b/packages/contracts/compare.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from packages.contracts.claims import NormalizedClaim
+from packages.contracts.product_intelligence import GapItem
+
+
+class CompareFilters(BaseModel):
+    claim_types: list[Literal["capability", "integration", "change_event"]] = Field(
+        default_factory=lambda: ["capability", "integration"]
+    )
+    min_confidence: float = Field(default=0.6, ge=0.0, le=1.0)
+    include_stale: bool = False
+    include_evidence: bool = False
+
+
+class CompareRequest(BaseModel):
+    left_product_id: str
+    right_product_id: str
+    filters: CompareFilters = Field(default_factory=CompareFilters)
+
+
+class ComparedClaim(BaseModel):
+    normalized_key: str
+    display_label: str
+    claim_type: str
+    left: NormalizedClaim | None
+    right: NormalizedClaim | None
+    verdict: Literal[
+        "shared",
+        "left_only",
+        "right_only",
+        "advantage_left",
+        "advantage_right",
+        "shared_but_left_stronger",
+        "shared_but_right_stronger",
+    ]
+
+
+class CompareSideSummary(BaseModel):
+    product_id: str
+    product_name: str
+    vendor_name: str
+    claim_count: int
+    high_confidence_claim_count: int
+    stale_claim_count: int
+    gap_count: int
+    last_crawled_at: datetime | None
+
+
+class CompareResponse(BaseModel):
+    generated_at: datetime
+    left: CompareSideSummary
+    right: CompareSideSummary
+    shared: list[ComparedClaim]
+    left_only: list[ComparedClaim]
+    right_only: list[ComparedClaim]
+    left_gaps: list[GapItem]
+    right_gaps: list[GapItem]

--- a/packages/services/compare_service.py
+++ b/packages/services/compare_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from packages.contracts.claims import NormalizedClaim
+from packages.contracts.compare import (
+    CompareRequest,
+    CompareResponse,
+    CompareSideSummary,
+    ComparedClaim,
+)
+from packages.services.product_intelligence import ProductIntelligenceService
+
+
+def _claim_key(claim: NormalizedClaim) -> tuple[str, str]:
+    return (claim.claim_type, claim.normalized_key)
+
+
+def _compare_claim_sets(
+    *,
+    left_claims: list[NormalizedClaim],
+    right_claims: list[NormalizedClaim],
+) -> tuple[list[ComparedClaim], list[ComparedClaim], list[ComparedClaim]]:
+    left_index = {_claim_key(claim): claim for claim in left_claims}
+    right_index = {_claim_key(claim): claim for claim in right_claims}
+    all_keys = sorted(set(left_index) | set(right_index), key=lambda item: (item[0], item[1]))
+
+    shared: list[ComparedClaim] = []
+    left_only: list[ComparedClaim] = []
+    right_only: list[ComparedClaim] = []
+
+    for key in all_keys:
+        left = left_index.get(key)
+        right = right_index.get(key)
+        claim_type, normalized_key = key
+        display_label = left.display_label if left else right.display_label  # type: ignore[union-attr]
+
+        if left and right:
+            delta = left.confidence - right.confidence
+            if abs(delta) < 0.1:
+                verdict = "shared"
+            elif delta > 0:
+                verdict = "shared_but_left_stronger"
+            else:
+                verdict = "shared_but_right_stronger"
+            shared.append(
+                ComparedClaim(
+                    normalized_key=normalized_key,
+                    display_label=display_label,
+                    claim_type=claim_type,
+                    left=left,
+                    right=right,
+                    verdict=verdict,
+                )
+            )
+            continue
+
+        if left:
+            left_only.append(
+                ComparedClaim(
+                    normalized_key=normalized_key,
+                    display_label=display_label,
+                    claim_type=claim_type,
+                    left=left,
+                    right=None,
+                    verdict="left_only",
+                )
+            )
+            continue
+
+        if right:
+            right_only.append(
+                ComparedClaim(
+                    normalized_key=normalized_key,
+                    display_label=display_label,
+                    claim_type=claim_type,
+                    left=None,
+                    right=right,
+                    verdict="right_only",
+                )
+            )
+
+    return shared, left_only, right_only
+
+
+class CompareService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.product_intelligence = ProductIntelligenceService(db)
+
+    def compare_products(self, request: CompareRequest) -> CompareResponse:
+        left_product_id = uuid.UUID(request.left_product_id)
+        right_product_id = uuid.UUID(request.right_product_id)
+
+        left_claims_response = self.product_intelligence.get_product_claims(
+            left_product_id,
+            min_confidence=request.filters.min_confidence,
+            include_stale=request.filters.include_stale,
+            include_evidence=request.filters.include_evidence,
+        )
+        right_claims_response = self.product_intelligence.get_product_claims(
+            right_product_id,
+            min_confidence=request.filters.min_confidence,
+            include_stale=request.filters.include_stale,
+            include_evidence=request.filters.include_evidence,
+        )
+
+        allowed_claim_types = set(request.filters.claim_types)
+        left_claims = [claim for claim in left_claims_response.items if claim.claim_type in allowed_claim_types]
+        right_claims = [claim for claim in right_claims_response.items if claim.claim_type in allowed_claim_types]
+
+        left_summary = self.product_intelligence.get_product_summary(
+            left_product_id,
+            min_confidence=request.filters.min_confidence,
+            include_evidence=False,
+        )
+        right_summary = self.product_intelligence.get_product_summary(
+            right_product_id,
+            min_confidence=request.filters.min_confidence,
+            include_evidence=False,
+        )
+
+        shared, left_only, right_only = _compare_claim_sets(
+            left_claims=left_claims,
+            right_claims=right_claims,
+        )
+
+        return CompareResponse(
+            generated_at=datetime.now(timezone.utc),
+            left=CompareSideSummary(
+                product_id=left_claims_response.product_id,
+                product_name=left_claims_response.product_name,
+                vendor_name=left_claims_response.vendor_name,
+                claim_count=len(left_claims),
+                high_confidence_claim_count=len([claim for claim in left_claims if claim.confidence >= 0.75]),
+                stale_claim_count=len([claim for claim in left_claims if "stale" in claim.flags]),
+                gap_count=len(left_summary.gaps),
+                last_crawled_at=left_summary.stats.last_crawled_at,
+            ),
+            right=CompareSideSummary(
+                product_id=right_claims_response.product_id,
+                product_name=right_claims_response.product_name,
+                vendor_name=right_claims_response.vendor_name,
+                claim_count=len(right_claims),
+                high_confidence_claim_count=len([claim for claim in right_claims if claim.confidence >= 0.75]),
+                stale_claim_count=len([claim for claim in right_claims if "stale" in claim.flags]),
+                gap_count=len(right_summary.gaps),
+                last_crawled_at=right_summary.stats.last_crawled_at,
+            ),
+            shared=shared,
+            left_only=left_only,
+            right_only=right_only,
+            left_gaps=left_summary.gaps,
+            right_gaps=right_summary.gaps,
+        )

--- a/tests/test_compare_routes.py
+++ b/tests/test_compare_routes.py
@@ -1,0 +1,136 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.contracts.claims import NormalizedClaim
+from packages.contracts.compare import CompareRequest, CompareResponse, CompareSideSummary, ComparedClaim
+from packages.contracts.product_intelligence import GapItem
+from packages.core.deps import get_db
+
+
+class DummyCompareService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def compare_products(self, request: CompareRequest) -> CompareResponse:
+        now = datetime.now(timezone.utc)
+        left_claim = NormalizedClaim(
+            claim_id="capability:single_sign_on",
+            claim_type="capability",
+            normalized_key="single_sign_on",
+            display_label="Single Sign-On",
+            confidence=0.88,
+            support_count=2,
+            source_count=2,
+            page_count=2,
+            freshness_score=1.0,
+            latest_evidence_at=now,
+            flags=["multi_source", "docs_backed"],
+            evidence=[],
+        )
+        right_claim = NormalizedClaim(
+            claim_id="capability:single_sign_on",
+            claim_type="capability",
+            normalized_key="single_sign_on",
+            display_label="Single Sign-On",
+            confidence=0.74,
+            support_count=1,
+            source_count=1,
+            page_count=1,
+            freshness_score=1.0,
+            latest_evidence_at=now,
+            flags=["thin_support"],
+            evidence=[],
+        )
+        return CompareResponse(
+            generated_at=now,
+            left=CompareSideSummary(
+                product_id=request.left_product_id,
+                product_name="Left Product",
+                vendor_name="Left Vendor",
+                claim_count=1,
+                high_confidence_claim_count=1,
+                stale_claim_count=0,
+                gap_count=1,
+                last_crawled_at=now,
+            ),
+            right=CompareSideSummary(
+                product_id=request.right_product_id,
+                product_name="Right Product",
+                vendor_name="Right Vendor",
+                claim_count=1,
+                high_confidence_claim_count=0,
+                stale_claim_count=0,
+                gap_count=2,
+                last_crawled_at=now,
+            ),
+            shared=[
+                ComparedClaim(
+                    normalized_key="single_sign_on",
+                    display_label="Single Sign-On",
+                    claim_type="capability",
+                    left=left_claim,
+                    right=right_claim,
+                    verdict="shared_but_left_stronger",
+                )
+            ],
+            left_only=[],
+            right_only=[],
+            left_gaps=[
+                GapItem(
+                    gap_code="missing_pricing_page",
+                    category="pricing",
+                    severity="high",
+                    message="Missing pricing page.",
+                    evidence_count=0,
+                    suggested_source_types=["pricing"],
+                )
+            ],
+            right_gaps=[
+                GapItem(
+                    gap_code="missing_docs_surface",
+                    category="docs",
+                    severity="high",
+                    message="Missing docs surface.",
+                    evidence_count=0,
+                    suggested_source_types=["docs_subdomain"],
+                )
+            ],
+        )
+
+
+def override_get_db():
+    yield object()
+
+
+def test_compare_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.compare.CompareService", DummyCompareService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    left_product_id = str(uuid4())
+    right_product_id = str(uuid4())
+
+    response = client.post(
+        "/v1/compare",
+        json={
+            "left_product_id": left_product_id,
+            "right_product_id": right_product_id,
+            "filters": {
+                "claim_types": ["capability", "integration"],
+                "min_confidence": 0.6,
+                "include_stale": False,
+                "include_evidence": False,
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["left"]["product_id"] == left_product_id
+    assert body["right"]["product_id"] == right_product_id
+    assert body["shared"][0]["verdict"] == "shared_but_left_stronger"
+    assert body["shared"][0]["normalized_key"] == "single_sign_on"
+
+    app.dependency_overrides.clear()

--- a/tests/test_compare_service.py
+++ b/tests/test_compare_service.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timezone
+
+from packages.contracts.claims import NormalizedClaim
+from packages.services.compare_service import _compare_claim_sets
+
+
+def _claim(*, claim_type: str, normalized_key: str, confidence: float) -> NormalizedClaim:
+    return NormalizedClaim(
+        claim_id=f"{claim_type}:{normalized_key}",
+        claim_type=claim_type,
+        normalized_key=normalized_key,
+        display_label=normalized_key.replace("_", " ").title(),
+        confidence=confidence,
+        support_count=1,
+        source_count=1,
+        page_count=1,
+        freshness_score=1.0,
+        latest_evidence_at=datetime.now(timezone.utc),
+        flags=[],
+        evidence=[],
+    )
+
+
+def test_compare_claim_sets_marks_stronger_and_unique_claims() -> None:
+    left_claims = [
+        _claim(claim_type="capability", normalized_key="single_sign_on", confidence=0.88),
+        _claim(claim_type="integration", normalized_key="salesforce", confidence=0.77),
+    ]
+    right_claims = [
+        _claim(claim_type="capability", normalized_key="single_sign_on", confidence=0.72),
+        _claim(claim_type="integration", normalized_key="slack", confidence=0.76),
+    ]
+
+    shared, left_only, right_only = _compare_claim_sets(left_claims=left_claims, right_claims=right_claims)
+
+    assert len(shared) == 1
+    assert shared[0].verdict == "shared_but_left_stronger"
+    assert len(left_only) == 1
+    assert left_only[0].normalized_key == "salesforce"
+    assert len(right_only) == 1
+    assert right_only[0].normalized_key == "slack"


### PR DESCRIPTION
## What this ships

Implements the next deterministic product surface on top of the claims foundation: `POST /v1/compare`.

### Added
- `packages/contracts/compare.py`
- `packages/services/compare_service.py`
- `apps/api/routes/compare.py`
- `tests/test_compare_routes.py`
- `tests/test_compare_service.py`

## Scope
- compares two products using normalized claims
- returns shared claims, left-only claims, and right-only claims
- uses stronger/weaker verdicts when both sides support the same claim with different confidence
- includes side summaries and gap summaries for each product

## Why now
This gives the API a real decision surface and creates the deterministic object the future Compare Analyst Agent will interpret.
