### PR TITLE
PR-005: add admin recrawl and replay actions

### DIFF
--- a/apps/api/routes/admin.py
+++ b/apps/api/routes/admin.py
@@ -2,8 +2,15 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from packages.contracts.admin import CrawlJobListResponse, EvidenceListResponse, PageListResponse
+from packages.contracts.admin_actions import (
+    CrawlJobReplayRequest,
+    CrawlJobReplayResponse,
+    SourceRecrawlRequest,
+    SourceRecrawlResponse,
+)
 from packages.contracts.api_common import ApiEnvelope
 from packages.core.deps import get_db
+from packages.services.admin_actions import AdminActionService
 from packages.services.admin_queries import AdminQueryService
 
 router = APIRouter(prefix="/v1/admin", tags=["admin"])
@@ -16,6 +23,26 @@ def list_crawl_jobs(
     db: Session = Depends(get_db),
 ) -> ApiEnvelope:
     result: CrawlJobListResponse = AdminQueryService(db).list_crawl_jobs(status=status, limit=limit)
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.post("/sources/{source_id}/recrawl", response_model=ApiEnvelope)
+def recrawl_source(
+    source_id: str,
+    payload: SourceRecrawlRequest,
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: SourceRecrawlResponse = AdminActionService(db).recrawl_source(source_id=source_id, request=payload)
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.post("/crawl-jobs/{crawl_job_id}/replay", response_model=ApiEnvelope)
+def replay_crawl_job(
+    crawl_job_id: str,
+    payload: CrawlJobReplayRequest,
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: CrawlJobReplayResponse = AdminActionService(db).replay_crawl_job(crawl_job_id=crawl_job_id, request=payload)
     return ApiEnvelope(data=result.model_dump())
 
 

--- a/packages/contracts/admin_actions.py
+++ b/packages/contracts/admin_actions.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field
+
+
+class SourceRecrawlRequest(BaseModel):
+    reason: str = "manual"
+    priority: int = Field(default=90, ge=0, le=100)
+    force: bool = False
+
+
+class SourceRecrawlResponse(BaseModel):
+    source_id: str
+    crawl_job_id: str
+    status: str
+    deduped: bool
+
+
+class CrawlJobReplayRequest(BaseModel):
+    priority: int = Field(default=90, ge=0, le=100)
+    reason: str = "manual_replay"
+
+
+class CrawlJobReplayResponse(BaseModel):
+    original_crawl_job_id: str
+    replay_crawl_job_id: str
+    status: str
+    deduped: bool

--- a/packages/services/admin_actions.py
+++ b/packages/services/admin_actions.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from packages.contracts.admin_actions import (
+    CrawlJobReplayRequest,
+    CrawlJobReplayResponse,
+    SourceRecrawlRequest,
+    SourceRecrawlResponse,
+)
+from packages.core.models import CrawlJob, Source
+
+_ACTIVE_JOB_STATUSES = {"queued", "leased", "retryable"}
+
+
+class AdminActionService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def recrawl_source(self, source_id: uuid.UUID, request: SourceRecrawlRequest) -> SourceRecrawlResponse:
+        source = self.db.get(Source, source_id)
+        if source is None:
+            raise ValueError(f"Source not found: {source_id}")
+
+        existing_job = self.db.execute(
+            select(CrawlJob).where(
+                CrawlJob.source_id == source_id,
+                CrawlJob.job_type == "fetch_source",
+                CrawlJob.status.in_(_ACTIVE_JOB_STATUSES),
+            )
+        ).scalar_one_or_none()
+        if existing_job is not None and not request.force:
+            return SourceRecrawlResponse(
+                source_id=str(source_id),
+                crawl_job_id=str(existing_job.crawl_job_id),
+                status="deduped",
+                deduped=True,
+            )
+
+        worker_queue = "browser_fetch" if source.connector_type == "browser" else "api_fetch"
+        job = CrawlJob(
+            vendor_id=source.vendor_id,
+            product_id=source.product_id,
+            source_id=source.source_id,
+            job_type="fetch_source",
+            worker_queue=worker_queue,
+            status="queued",
+            priority=request.priority,
+            max_attempts=3,
+            payload={
+                "source_id": str(source.source_id),
+                "product_id": str(source.product_id) if source.product_id else None,
+                "vendor_id": str(source.vendor_id) if source.vendor_id else None,
+                "root_url": source.root_url,
+                "source_type": source.source_type,
+                "reason": request.reason,
+                "trigger": "admin_recrawl",
+                "force": request.force,
+            },
+        )
+        self.db.add(job)
+        self.db.commit()
+        self.db.refresh(job)
+        return SourceRecrawlResponse(
+            source_id=str(source_id),
+            crawl_job_id=str(job.crawl_job_id),
+            status="queued",
+            deduped=False,
+        )
+
+    def replay_crawl_job(self, crawl_job_id: uuid.UUID, request: CrawlJobReplayRequest) -> CrawlJobReplayResponse:
+        original_job = self.db.get(CrawlJob, crawl_job_id)
+        if original_job is None:
+            raise ValueError(f"Crawl job not found: {crawl_job_id}")
+
+        existing_job = self.db.execute(
+            select(CrawlJob).where(
+                CrawlJob.source_id == original_job.source_id,
+                CrawlJob.job_type == original_job.job_type,
+                CrawlJob.status.in_(_ACTIVE_JOB_STATUSES),
+            )
+        ).scalar_one_or_none()
+        if existing_job is not None:
+            return CrawlJobReplayResponse(
+                original_crawl_job_id=str(crawl_job_id),
+                replay_crawl_job_id=str(existing_job.crawl_job_id),
+                status="deduped",
+                deduped=True,
+            )
+
+        replay_job = CrawlJob(
+            vendor_id=original_job.vendor_id,
+            product_id=original_job.product_id,
+            source_id=original_job.source_id,
+            job_type=original_job.job_type,
+            worker_queue=original_job.worker_queue,
+            status="queued",
+            priority=request.priority,
+            max_attempts=original_job.max_attempts,
+            payload={
+                **original_job.payload,
+                "reason": request.reason,
+                "trigger": "admin_replay",
+                "replayed_from": str(original_job.crawl_job_id),
+            },
+        )
+        self.db.add(replay_job)
+        self.db.commit()
+        self.db.refresh(replay_job)
+        return CrawlJobReplayResponse(
+            original_crawl_job_id=str(crawl_job_id),
+            replay_crawl_job_id=str(replay_job.crawl_job_id),
+            status="queued",
+            deduped=False,
+        )

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -1,0 +1,118 @@
+from uuid import uuid4
+
+from packages.contracts.admin_actions import CrawlJobReplayRequest, SourceRecrawlRequest
+from packages.services.admin_actions import AdminActionService
+
+
+class DummySource:
+    def __init__(self) -> None:
+        self.source_id = uuid4()
+        self.vendor_id = uuid4()
+        self.product_id = uuid4()
+        self.root_url = "https://example.com"
+        self.source_type = "homepage"
+        self.connector_type = "browser"
+
+
+class DummyJob:
+    def __init__(self) -> None:
+        self.crawl_job_id = uuid4()
+        self.source_id = uuid4()
+        self.vendor_id = uuid4()
+        self.product_id = uuid4()
+        self.job_type = "fetch_source"
+        self.worker_queue = "browser_fetch"
+        self.max_attempts = 3
+        self.payload = {"root_url": "https://example.com"}
+
+
+class DummyScalarResult:
+    def __init__(self, value) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class DummySession:
+    def __init__(self, source=None, existing_job=None, original_job=None) -> None:
+        self.source = source
+        self.existing_job = existing_job
+        self.original_job = original_job
+        self.added = []
+
+    def get(self, model, object_id):
+        model_name = getattr(model, "__name__", "")
+        if model_name == "Source":
+            return self.source
+        if model_name == "CrawlJob":
+            return self.original_job
+        return None
+
+    def execute(self, stmt):
+        return DummyScalarResult(self.existing_job)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        return None
+
+    def refresh(self, obj):
+        return None
+
+
+def test_recrawl_source_dedupes_existing_active_job() -> None:
+    source = DummySource()
+    existing_job = DummyJob()
+    session = DummySession(source=source, existing_job=existing_job)
+
+    result = AdminActionService(session).recrawl_source(source.source_id, SourceRecrawlRequest())
+
+    assert result.deduped is True
+    assert result.status == "deduped"
+    assert result.crawl_job_id == str(existing_job.crawl_job_id)
+    assert session.added == []
+
+
+def test_recrawl_source_creates_new_job_when_forced() -> None:
+    source = DummySource()
+    existing_job = DummyJob()
+    session = DummySession(source=source, existing_job=existing_job)
+
+    result = AdminActionService(session).recrawl_source(
+        source.source_id,
+        SourceRecrawlRequest(force=True, priority=95, reason="manual"),
+    )
+
+    assert result.deduped is False
+    assert result.status == "queued"
+    assert len(session.added) == 1
+    assert session.added[0].priority == 95
+
+
+def test_replay_crawl_job_dedupes_existing_active_job() -> None:
+    original_job = DummyJob()
+    existing_job = DummyJob()
+    session = DummySession(existing_job=existing_job, original_job=original_job)
+
+    result = AdminActionService(session).replay_crawl_job(original_job.crawl_job_id, CrawlJobReplayRequest())
+
+    assert result.deduped is True
+    assert result.status == "deduped"
+    assert result.replay_crawl_job_id == str(existing_job.crawl_job_id)
+
+
+def test_replay_crawl_job_creates_new_job_when_no_active_job_exists() -> None:
+    original_job = DummyJob()
+    session = DummySession(existing_job=None, original_job=original_job)
+
+    result = AdminActionService(session).replay_crawl_job(
+        original_job.crawl_job_id,
+        CrawlJobReplayRequest(priority=91, reason="manual_replay"),
+    )
+
+    assert result.deduped is False
+    assert result.status == "queued"
+    assert len(session.added) == 1
+    assert session.added[0].priority == 91

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -7,13 +7,14 @@ from apps.api.main import app
 from packages.contracts.admin import (
     CrawlJobListResponse,
     CrawlJobSummary,
-    VendorSourcesResponse,
     SourceSummary,
+    VendorSourcesResponse,
 )
+from packages.contracts.admin_actions import CrawlJobReplayResponse, SourceRecrawlResponse
 from packages.core.deps import get_db
 
 
-class DummyService:
+class DummyQueryService:
     def __init__(self, _db: object) -> None:
         pass
 
@@ -63,12 +64,33 @@ class DummyService:
         )
 
 
+class DummyActionService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def recrawl_source(self, source_id, request):
+        return SourceRecrawlResponse(
+            source_id=str(source_id),
+            crawl_job_id=str(uuid.uuid4()),
+            status="queued",
+            deduped=False,
+        )
+
+    def replay_crawl_job(self, crawl_job_id, request):
+        return CrawlJobReplayResponse(
+            original_crawl_job_id=str(crawl_job_id),
+            replay_crawl_job_id=str(uuid.uuid4()),
+            status="queued",
+            deduped=False,
+        )
+
+
 def override_get_db():
     yield object()
 
 
 def test_admin_crawl_jobs_endpoint_returns_payload(monkeypatch) -> None:
-    monkeypatch.setattr("apps.api.routes.admin.AdminQueryService", DummyService)
+    monkeypatch.setattr("apps.api.routes.admin.AdminQueryService", DummyQueryService)
     app.dependency_overrides[get_db] = override_get_db
     client = TestClient(app)
 
@@ -82,8 +104,46 @@ def test_admin_crawl_jobs_endpoint_returns_payload(monkeypatch) -> None:
     app.dependency_overrides.clear()
 
 
+def test_admin_recrawl_source_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin.AdminActionService", DummyActionService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    source_id = uuid.uuid4()
+
+    response = client.post(
+        f"/v1/admin/sources/{source_id}/recrawl",
+        json={"reason": "manual", "priority": 95, "force": False},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["source_id"] == str(source_id)
+    assert body["status"] == "queued"
+
+    app.dependency_overrides.clear()
+
+
+def test_admin_replay_crawl_job_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin.AdminActionService", DummyActionService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    crawl_job_id = uuid.uuid4()
+
+    response = client.post(
+        f"/v1/admin/crawl-jobs/{crawl_job_id}/replay",
+        json={"priority": 91, "reason": "manual_replay"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["original_crawl_job_id"] == str(crawl_job_id)
+    assert body["status"] == "queued"
+
+    app.dependency_overrides.clear()
+
+
 def test_vendor_sources_endpoint_returns_payload(monkeypatch) -> None:
-    monkeypatch.setattr("apps.api.routes.vendors.AdminQueryService", DummyService)
+    monkeypatch.setattr("apps.api.routes.vendors.AdminQueryService", DummyQueryService)
     app.dependency_overrides[get_db] = override_get_db
     client = TestClient(app)
     vendor_id = uuid.uuid4()


### PR DESCRIPTION
## What this ships

Adds the next deterministic operator surface for the crawl system.

### Added
- `packages/contracts/admin_actions.py`
- `packages/services/admin_actions.py`
- `tests/test_admin_actions.py`

### In progress in this PR
- route wiring for admin recrawl/replay
- route coverage for the admin mutation endpoints

## Scope
- `POST /v1/admin/sources/{source_id}/recrawl`
- `POST /v1/admin/crawl-jobs/{crawl_job_id}/replay`
- dedupes active jobs instead of blindly creating duplicates
- reuses existing crawl job/source model and queue shape
