### PR TITLE
PR-006: add tracing and eval substrate

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -5,12 +5,14 @@ from apps.api.routes.compare import router as compare_router
 from apps.api.routes.products import router as products_router
 from apps.api.routes.vendors import router as vendors_router
 from packages.core.config import get_settings
+from packages.observability.middleware import RequestTracingMiddleware
 
 app = FastAPI(
     title="BMT API",
     version="0.1.0",
     description="Evidence-backed vendor understanding API.",
 )
+app.add_middleware(RequestTracingMiddleware)
 
 app.include_router(vendors_router)
 app.include_router(admin_router)

--- a/packages/observability/middleware.py
+++ b/packages/observability/middleware.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import time
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+from packages.observability.tracing import clear_trace_context, generate_trace_id, log_event, set_trace_context
+
+
+class RequestTracingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        request_id = request.headers.get("x-request-id") or generate_trace_id()
+        trace_id = request.headers.get("x-trace-id") or generate_trace_id()
+        set_trace_context(trace_id=trace_id, request_id=request_id)
+
+        started_at = time.perf_counter()
+        log_event(
+            "http.server.request.started",
+            http_method=request.method,
+            http_route=str(request.url.path),
+        )
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = round((time.perf_counter() - started_at) * 1000, 3)
+            log_event(
+                "http.server.request.failed",
+                http_method=request.method,
+                http_route=str(request.url.path),
+                duration_ms=duration_ms,
+            )
+            clear_trace_context()
+            raise
+
+        duration_ms = round((time.perf_counter() - started_at) * 1000, 3)
+        response.headers["x-request-id"] = request_id
+        response.headers["x-trace-id"] = trace_id
+        log_event(
+            "http.server.request.completed",
+            http_method=request.method,
+            http_route=str(request.url.path),
+            http_status_code=response.status_code,
+            duration_ms=duration_ms,
+        )
+        clear_trace_context()
+        return response

--- a/packages/observability/tracing.py
+++ b/packages/observability/tracing.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import time
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator
+
+import structlog
+
+_TRACE_ID: ContextVar[str | None] = ContextVar("trace_id", default=None)
+_REQUEST_ID: ContextVar[str | None] = ContextVar("request_id", default=None)
+_SPAN_STACK: ContextVar[list[str]] = ContextVar("span_stack", default=[])
+
+logger = structlog.get_logger("bmt_api.tracing")
+
+
+def generate_trace_id() -> str:
+    return uuid.uuid4().hex
+
+
+def generate_span_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def set_trace_context(*, trace_id: str, request_id: str | None = None) -> None:
+    _TRACE_ID.set(trace_id)
+    if request_id is not None:
+        _REQUEST_ID.set(request_id)
+
+
+def clear_trace_context() -> None:
+    _TRACE_ID.set(None)
+    _REQUEST_ID.set(None)
+    _SPAN_STACK.set([])
+
+
+def get_trace_context() -> dict[str, str | None]:
+    span_stack = _SPAN_STACK.get()
+    active_span_id = span_stack[-1] if span_stack else None
+    return {
+        "trace_id": _TRACE_ID.get(),
+        "request_id": _REQUEST_ID.get(),
+        "span_id": active_span_id,
+    }
+
+
+def log_event(event_name: str, **attributes: Any) -> None:
+    logger.info(event_name, **get_trace_context(), **attributes)
+
+
+@contextmanager
+def traced_span(name: str, **attributes: Any) -> Iterator[str]:
+    span_id = generate_span_id()
+    parent_context = get_trace_context()
+    parent_span_id = parent_context.get("span_id")
+    span_stack = list(_SPAN_STACK.get())
+    span_stack.append(span_id)
+    token = _SPAN_STACK.set(span_stack)
+    started_at = time.perf_counter()
+    logger.info(
+        "span.started",
+        **get_trace_context(),
+        span_name=name,
+        parent_span_id=parent_span_id,
+        **attributes,
+    )
+    try:
+        yield span_id
+    except Exception as exc:
+        duration_ms = round((time.perf_counter() - started_at) * 1000, 3)
+        logger.exception(
+            "span.failed",
+            **get_trace_context(),
+            span_name=name,
+            parent_span_id=parent_span_id,
+            duration_ms=duration_ms,
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+            **attributes,
+        )
+        raise
+    else:
+        duration_ms = round((time.perf_counter() - started_at) * 1000, 3)
+        logger.info(
+            "span.completed",
+            **get_trace_context(),
+            span_name=name,
+            parent_span_id=parent_span_id,
+            duration_ms=duration_ms,
+            **attributes,
+        )
+    finally:
+        _SPAN_STACK.reset(token)

--- a/packages/services/admin_actions.py
+++ b/packages/services/admin_actions.py
@@ -12,6 +12,7 @@ from packages.contracts.admin_actions import (
     SourceRecrawlResponse,
 )
 from packages.core.models import CrawlJob, Source
+from packages.observability.tracing import log_event, traced_span
 
 _ACTIVE_JOB_STATUSES = {"queued", "leased", "retryable"}
 
@@ -21,98 +22,122 @@ class AdminActionService:
         self.db = db
 
     def recrawl_source(self, source_id: uuid.UUID, request: SourceRecrawlRequest) -> SourceRecrawlResponse:
-        source = self.db.get(Source, source_id)
-        if source is None:
-            raise ValueError(f"Source not found: {source_id}")
+        with traced_span("admin.recrawl_source", source_id=str(source_id), force=request.force):
+            source = self.db.get(Source, source_id)
+            if source is None:
+                raise ValueError(f"Source not found: {source_id}")
 
-        existing_job = self.db.execute(
-            select(CrawlJob).where(
-                CrawlJob.source_id == source_id,
-                CrawlJob.job_type == "fetch_source",
-                CrawlJob.status.in_(_ACTIVE_JOB_STATUSES),
+            existing_job = self.db.execute(
+                select(CrawlJob).where(
+                    CrawlJob.source_id == source_id,
+                    CrawlJob.job_type == "fetch_source",
+                    CrawlJob.status.in_(_ACTIVE_JOB_STATUSES),
+                )
+            ).scalar_one_or_none()
+            if existing_job is not None and not request.force:
+                log_event(
+                    "admin.recrawl_source.deduped",
+                    source_id=str(source_id),
+                    existing_crawl_job_id=str(existing_job.crawl_job_id),
+                )
+                return SourceRecrawlResponse(
+                    source_id=str(source_id),
+                    crawl_job_id=str(existing_job.crawl_job_id),
+                    status="deduped",
+                    deduped=True,
+                )
+
+            worker_queue = "browser_fetch" if source.connector_type == "browser" else "api_fetch"
+            job = CrawlJob(
+                vendor_id=source.vendor_id,
+                product_id=source.product_id,
+                source_id=source.source_id,
+                job_type="fetch_source",
+                worker_queue=worker_queue,
+                status="queued",
+                priority=request.priority,
+                max_attempts=3,
+                payload={
+                    "source_id": str(source.source_id),
+                    "product_id": str(source.product_id) if source.product_id else None,
+                    "vendor_id": str(source.vendor_id) if source.vendor_id else None,
+                    "root_url": source.root_url,
+                    "source_type": source.source_type,
+                    "reason": request.reason,
+                    "trigger": "admin_recrawl",
+                    "force": request.force,
+                },
             )
-        ).scalar_one_or_none()
-        if existing_job is not None and not request.force:
+            self.db.add(job)
+            self.db.commit()
+            self.db.refresh(job)
+            log_event(
+                "admin.recrawl_source.queued",
+                source_id=str(source_id),
+                crawl_job_id=str(job.crawl_job_id),
+                priority=request.priority,
+            )
             return SourceRecrawlResponse(
                 source_id=str(source_id),
-                crawl_job_id=str(existing_job.crawl_job_id),
-                status="deduped",
-                deduped=True,
+                crawl_job_id=str(job.crawl_job_id),
+                status="queued",
+                deduped=False,
             )
-
-        worker_queue = "browser_fetch" if source.connector_type == "browser" else "api_fetch"
-        job = CrawlJob(
-            vendor_id=source.vendor_id,
-            product_id=source.product_id,
-            source_id=source.source_id,
-            job_type="fetch_source",
-            worker_queue=worker_queue,
-            status="queued",
-            priority=request.priority,
-            max_attempts=3,
-            payload={
-                "source_id": str(source.source_id),
-                "product_id": str(source.product_id) if source.product_id else None,
-                "vendor_id": str(source.vendor_id) if source.vendor_id else None,
-                "root_url": source.root_url,
-                "source_type": source.source_type,
-                "reason": request.reason,
-                "trigger": "admin_recrawl",
-                "force": request.force,
-            },
-        )
-        self.db.add(job)
-        self.db.commit()
-        self.db.refresh(job)
-        return SourceRecrawlResponse(
-            source_id=str(source_id),
-            crawl_job_id=str(job.crawl_job_id),
-            status="queued",
-            deduped=False,
-        )
 
     def replay_crawl_job(self, crawl_job_id: uuid.UUID, request: CrawlJobReplayRequest) -> CrawlJobReplayResponse:
-        original_job = self.db.get(CrawlJob, crawl_job_id)
-        if original_job is None:
-            raise ValueError(f"Crawl job not found: {crawl_job_id}")
+        with traced_span("admin.replay_crawl_job", crawl_job_id=str(crawl_job_id)):
+            original_job = self.db.get(CrawlJob, crawl_job_id)
+            if original_job is None:
+                raise ValueError(f"Crawl job not found: {crawl_job_id}")
 
-        existing_job = self.db.execute(
-            select(CrawlJob).where(
-                CrawlJob.source_id == original_job.source_id,
-                CrawlJob.job_type == original_job.job_type,
-                CrawlJob.status.in_(_ACTIVE_JOB_STATUSES),
+            existing_job = self.db.execute(
+                select(CrawlJob).where(
+                    CrawlJob.source_id == original_job.source_id,
+                    CrawlJob.job_type == original_job.job_type,
+                    CrawlJob.status.in_(_ACTIVE_JOB_STATUSES),
+                )
+            ).scalar_one_or_none()
+            if existing_job is not None:
+                log_event(
+                    "admin.replay_crawl_job.deduped",
+                    original_crawl_job_id=str(crawl_job_id),
+                    existing_crawl_job_id=str(existing_job.crawl_job_id),
+                )
+                return CrawlJobReplayResponse(
+                    original_crawl_job_id=str(crawl_job_id),
+                    replay_crawl_job_id=str(existing_job.crawl_job_id),
+                    status="deduped",
+                    deduped=True,
+                )
+
+            replay_job = CrawlJob(
+                vendor_id=original_job.vendor_id,
+                product_id=original_job.product_id,
+                source_id=original_job.source_id,
+                job_type=original_job.job_type,
+                worker_queue=original_job.worker_queue,
+                status="queued",
+                priority=request.priority,
+                max_attempts=original_job.max_attempts,
+                payload={
+                    **original_job.payload,
+                    "reason": request.reason,
+                    "trigger": "admin_replay",
+                    "replayed_from": str(original_job.crawl_job_id),
+                },
             )
-        ).scalar_one_or_none()
-        if existing_job is not None:
+            self.db.add(replay_job)
+            self.db.commit()
+            self.db.refresh(replay_job)
+            log_event(
+                "admin.replay_crawl_job.queued",
+                original_crawl_job_id=str(crawl_job_id),
+                replay_crawl_job_id=str(replay_job.crawl_job_id),
+                priority=request.priority,
+            )
             return CrawlJobReplayResponse(
                 original_crawl_job_id=str(crawl_job_id),
-                replay_crawl_job_id=str(existing_job.crawl_job_id),
-                status="deduped",
-                deduped=True,
+                replay_crawl_job_id=str(replay_job.crawl_job_id),
+                status="queued",
+                deduped=False,
             )
-
-        replay_job = CrawlJob(
-            vendor_id=original_job.vendor_id,
-            product_id=original_job.product_id,
-            source_id=original_job.source_id,
-            job_type=original_job.job_type,
-            worker_queue=original_job.worker_queue,
-            status="queued",
-            priority=request.priority,
-            max_attempts=original_job.max_attempts,
-            payload={
-                **original_job.payload,
-                "reason": request.reason,
-                "trigger": "admin_replay",
-                "replayed_from": str(original_job.crawl_job_id),
-            },
-        )
-        self.db.add(replay_job)
-        self.db.commit()
-        self.db.refresh(replay_job)
-        return CrawlJobReplayResponse(
-            original_crawl_job_id=str(crawl_job_id),
-            replay_crawl_job_id=str(replay_job.crawl_job_id),
-            status="queued",
-            deduped=False,
-        )

--- a/packages/services/compare_service.py
+++ b/packages/services/compare_service.py
@@ -12,6 +12,7 @@ from packages.contracts.compare import (
     CompareSideSummary,
     ComparedClaim,
 )
+from packages.observability.tracing import log_event, traced_span
 from packages.services.product_intelligence import ProductIntelligenceService
 
 
@@ -95,64 +96,75 @@ class CompareService:
         left_product_id = uuid.UUID(request.left_product_id)
         right_product_id = uuid.UUID(request.right_product_id)
 
-        left_claims_response = self.product_intelligence.get_product_claims(
-            left_product_id,
-            min_confidence=request.filters.min_confidence,
-            include_stale=request.filters.include_stale,
-            include_evidence=request.filters.include_evidence,
-        )
-        right_claims_response = self.product_intelligence.get_product_claims(
-            right_product_id,
-            min_confidence=request.filters.min_confidence,
-            include_stale=request.filters.include_stale,
-            include_evidence=request.filters.include_evidence,
-        )
+        with traced_span(
+            "compare.products",
+            left_product_id=str(left_product_id),
+            right_product_id=str(right_product_id),
+        ):
+            left_claims_response = self.product_intelligence.get_product_claims(
+                left_product_id,
+                min_confidence=request.filters.min_confidence,
+                include_stale=request.filters.include_stale,
+                include_evidence=request.filters.include_evidence,
+            )
+            right_claims_response = self.product_intelligence.get_product_claims(
+                right_product_id,
+                min_confidence=request.filters.min_confidence,
+                include_stale=request.filters.include_stale,
+                include_evidence=request.filters.include_evidence,
+            )
 
-        allowed_claim_types = set(request.filters.claim_types)
-        left_claims = [claim for claim in left_claims_response.items if claim.claim_type in allowed_claim_types]
-        right_claims = [claim for claim in right_claims_response.items if claim.claim_type in allowed_claim_types]
+            allowed_claim_types = set(request.filters.claim_types)
+            left_claims = [claim for claim in left_claims_response.items if claim.claim_type in allowed_claim_types]
+            right_claims = [claim for claim in right_claims_response.items if claim.claim_type in allowed_claim_types]
 
-        left_summary = self.product_intelligence.get_product_summary(
-            left_product_id,
-            min_confidence=request.filters.min_confidence,
-            include_evidence=False,
-        )
-        right_summary = self.product_intelligence.get_product_summary(
-            right_product_id,
-            min_confidence=request.filters.min_confidence,
-            include_evidence=False,
-        )
+            left_summary = self.product_intelligence.get_product_summary(
+                left_product_id,
+                min_confidence=request.filters.min_confidence,
+                include_evidence=False,
+            )
+            right_summary = self.product_intelligence.get_product_summary(
+                right_product_id,
+                min_confidence=request.filters.min_confidence,
+                include_evidence=False,
+            )
 
-        shared, left_only, right_only = _compare_claim_sets(
-            left_claims=left_claims,
-            right_claims=right_claims,
-        )
+            shared, left_only, right_only = _compare_claim_sets(
+                left_claims=left_claims,
+                right_claims=right_claims,
+            )
+            log_event(
+                "compare.products.completed",
+                shared_count=len(shared),
+                left_only_count=len(left_only),
+                right_only_count=len(right_only),
+            )
 
-        return CompareResponse(
-            generated_at=datetime.now(timezone.utc),
-            left=CompareSideSummary(
-                product_id=left_claims_response.product_id,
-                product_name=left_claims_response.product_name,
-                vendor_name=left_claims_response.vendor_name,
-                claim_count=len(left_claims),
-                high_confidence_claim_count=len([claim for claim in left_claims if claim.confidence >= 0.75]),
-                stale_claim_count=len([claim for claim in left_claims if "stale" in claim.flags]),
-                gap_count=len(left_summary.gaps),
-                last_crawled_at=left_summary.stats.last_crawled_at,
-            ),
-            right=CompareSideSummary(
-                product_id=right_claims_response.product_id,
-                product_name=right_claims_response.product_name,
-                vendor_name=right_claims_response.vendor_name,
-                claim_count=len(right_claims),
-                high_confidence_claim_count=len([claim for claim in right_claims if claim.confidence >= 0.75]),
-                stale_claim_count=len([claim for claim in right_claims if "stale" in claim.flags]),
-                gap_count=len(right_summary.gaps),
-                last_crawled_at=right_summary.stats.last_crawled_at,
-            ),
-            shared=shared,
-            left_only=left_only,
-            right_only=right_only,
-            left_gaps=left_summary.gaps,
-            right_gaps=right_summary.gaps,
-        )
+            return CompareResponse(
+                generated_at=datetime.now(timezone.utc),
+                left=CompareSideSummary(
+                    product_id=left_claims_response.product_id,
+                    product_name=left_claims_response.product_name,
+                    vendor_name=left_claims_response.vendor_name,
+                    claim_count=len(left_claims),
+                    high_confidence_claim_count=len([claim for claim in left_claims if claim.confidence >= 0.75]),
+                    stale_claim_count=len([claim for claim in left_claims if "stale" in claim.flags]),
+                    gap_count=len(left_summary.gaps),
+                    last_crawled_at=left_summary.stats.last_crawled_at,
+                ),
+                right=CompareSideSummary(
+                    product_id=right_claims_response.product_id,
+                    product_name=right_claims_response.product_name,
+                    vendor_name=right_claims_response.vendor_name,
+                    claim_count=len(right_claims),
+                    high_confidence_claim_count=len([claim for claim in right_claims if claim.confidence >= 0.75]),
+                    stale_claim_count=len([claim for claim in right_claims if "stale" in claim.flags]),
+                    gap_count=len(right_summary.gaps),
+                    last_crawled_at=right_summary.stats.last_crawled_at,
+                ),
+                shared=shared,
+                left_only=left_only,
+                right_only=right_only,
+                left_gaps=left_summary.gaps,
+                right_gaps=right_summary.gaps,
+            )

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,40 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.observability.tracing import clear_trace_context, get_trace_context, set_trace_context
+
+
+def test_request_tracing_middleware_sets_response_headers() -> None:
+    client = TestClient(app)
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.headers.get("x-request-id")
+    assert response.headers.get("x-trace-id")
+
+
+def test_request_tracing_middleware_preserves_incoming_headers() -> None:
+    client = TestClient(app)
+
+    response = client.get(
+        "/healthz",
+        headers={"x-request-id": "req-123", "x-trace-id": "trace-123"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["x-request-id"] == "req-123"
+    assert response.headers["x-trace-id"] == "trace-123"
+
+
+def test_trace_context_round_trip() -> None:
+    clear_trace_context()
+    set_trace_context(trace_id="trace-a", request_id="request-a")
+
+    context = get_trace_context()
+
+    assert context["trace_id"] == "trace-a"
+    assert context["request_id"] == "request-a"
+    assert context["span_id"] is None
+
+    clear_trace_context()


### PR DESCRIPTION
## What this ships

Adds the first tracing substrate needed before agent rollout.

### Added
- `packages/observability/tracing.py`
- `packages/observability/middleware.py`
- `tests/test_tracing.py`

### In progress in this PR
- app middleware registration
- span/event hooks in compare and admin action services

## Scope
- request and trace IDs on inbound HTTP requests
- structured span/event helpers for future agent traces
- response headers for request/trace correlation
- initial span hooks for deterministic compare and admin action flows

## Why now
Research is consistent that traces and evals should come before autonomy. This PR creates the minimal substrate we need before adding the first real agents.
