### PR TITLE
PR-007: add source planner agent scaffold

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from apps.api.routes.admin import router as admin_router
+from apps.api.routes.agents import router as agents_router
 from apps.api.routes.compare import router as compare_router
 from apps.api.routes.products import router as products_router
 from apps.api.routes.vendors import router as vendors_router
@@ -18,6 +19,7 @@ app.include_router(vendors_router)
 app.include_router(admin_router)
 app.include_router(products_router)
 app.include_router(compare_router)
+app.include_router(agents_router)
 
 
 @app.get("/healthz", tags=["system"])

--- a/apps/api/routes/agents.py
+++ b/apps/api/routes/agents.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from packages.contracts.agents import SourcePlannerRequest, SourcePlannerResponse
+from packages.contracts.api_common import ApiEnvelope
+from packages.core.deps import get_db
+from packages.services.source_planner_agent import SourcePlannerAgentService
+
+router = APIRouter(prefix="/v1/agents", tags=["agents"])
+
+
+@router.post("/source-planner/plan", response_model=ApiEnvelope)
+def plan_sources(payload: SourcePlannerRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: SourcePlannerResponse = SourcePlannerAgentService(db).plan(payload)
+    return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/agents.py
+++ b/packages/contracts/agents.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel, Field
+
+
+class SourcePlannerRequest(BaseModel):
+    product_id: str
+    max_candidates: int = Field(default=5, ge=1, le=20)
+    include_existing_sources: bool = False
+
+
+class SourceProposal(BaseModel):
+    root_url: str
+    source_type: str
+    source_family: str = "vendor_owned"
+    connector_type: str = "browser"
+    reason: str
+    target_gap_codes: list[str] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class AgentRunSummary(BaseModel):
+    agent_name: str
+    strategy_version: str
+    mode: str
+
+
+class SourcePlannerResponse(BaseModel):
+    product_id: str
+    agent: AgentRunSummary
+    considered_gap_codes: list[str] = Field(default_factory=list)
+    proposals: list[SourceProposal] = Field(default_factory=list)

--- a/packages/services/source_planner_agent.py
+++ b/packages/services/source_planner_agent.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import uuid
+from collections import OrderedDict
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from packages.contracts.agents import AgentRunSummary, SourcePlannerRequest, SourcePlannerResponse, SourceProposal
+from packages.core.models import Product, Source, Vendor
+from packages.observability.tracing import log_event, traced_span
+from packages.services.gap_detector import detect_product_gaps
+from packages.services.product_intelligence import ProductIntelligenceService, build_normalized_claims
+
+STRATEGY_VERSION = "source_planner_v1"
+
+
+class SourcePlannerAgentService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.product_intelligence = ProductIntelligenceService(db)
+
+    def plan(self, request: SourcePlannerRequest) -> SourcePlannerResponse:
+        product_id = uuid.UUID(request.product_id)
+        with traced_span("agent.source_planner.plan", product_id=request.product_id):
+            context = self._get_product_vendor_context(product_id)
+            claim_rows = self.product_intelligence._get_claim_rows(product_id)
+            claims = build_normalized_claims(rows=claim_rows, include_stale=True, include_evidence=False)
+            page_types = self.product_intelligence._get_page_types(product_id)
+            gaps = detect_product_gaps(page_types=page_types, claims=claims)
+            existing_sources = self._get_existing_sources(product_id)
+            proposals = self._build_proposals(
+                primary_domain=context["primary_domain"],
+                gaps=gaps,
+                existing_sources=existing_sources,
+                include_existing_sources=request.include_existing_sources,
+                max_candidates=request.max_candidates,
+            )
+            log_event(
+                "agent.source_planner.completed",
+                product_id=request.product_id,
+                gap_count=len(gaps),
+                proposal_count=len(proposals),
+            )
+            return SourcePlannerResponse(
+                product_id=request.product_id,
+                agent=AgentRunSummary(
+                    agent_name="source_planner_agent",
+                    strategy_version=STRATEGY_VERSION,
+                    mode="heuristic_scaffold",
+                ),
+                considered_gap_codes=[gap.gap_code for gap in gaps],
+                proposals=proposals,
+            )
+
+    def _get_product_vendor_context(self, product_id: uuid.UUID) -> dict[str, str | None]:
+        row = self.db.execute(
+            select(Product, Vendor)
+            .join(Vendor, Product.vendor_id == Vendor.vendor_id)
+            .where(Product.product_id == product_id)
+        ).one_or_none()
+        if row is None:
+            raise ValueError(f"Product not found: {product_id}")
+        product, vendor = row
+        return {
+            "product_name": product.canonical_name,
+            "primary_domain": vendor.primary_domain,
+        }
+
+    def _get_existing_sources(self, product_id: uuid.UUID) -> set[str]:
+        rows = self.db.execute(select(Source.root_url).where(Source.product_id == product_id)).scalars()
+        return set(rows)
+
+    def _build_proposals(
+        self,
+        *,
+        primary_domain: str | None,
+        gaps,
+        existing_sources: set[str],
+        include_existing_sources: bool,
+        max_candidates: int,
+    ) -> list[SourceProposal]:
+        if not primary_domain:
+            return []
+
+        candidates: OrderedDict[str, SourceProposal] = OrderedDict()
+
+        def add(url: str, source_type: str, reason: str, gap_code: str, confidence: float) -> None:
+            if not include_existing_sources and url in existing_sources:
+                return
+            if url in candidates:
+                proposal = candidates[url]
+                if gap_code not in proposal.target_gap_codes:
+                    proposal.target_gap_codes.append(gap_code)
+                return
+            candidates[url] = SourceProposal(
+                root_url=url,
+                source_type=source_type,
+                reason=reason,
+                target_gap_codes=[gap_code],
+                confidence=confidence,
+            )
+
+        for gap in gaps:
+            if gap.gap_code == "missing_pricing_page":
+                add(
+                    f"https://{primary_domain}/pricing",
+                    "pricing",
+                    "Pricing coverage is missing, so the canonical pricing page is the highest-leverage next source.",
+                    gap.gap_code,
+                    0.93,
+                )
+            elif gap.gap_code == "missing_docs_surface":
+                add(
+                    f"https://docs.{primary_domain}",
+                    "docs_subdomain",
+                    "Docs coverage is missing, so the docs subdomain is the most likely source of durable feature evidence.",
+                    gap.gap_code,
+                    0.9,
+                )
+                add(
+                    f"https://{primary_domain}/docs",
+                    "docs_path",
+                    "The docs path often exposes product capabilities and integration proof when docs live on the main domain.",
+                    gap.gap_code,
+                    0.84,
+                )
+                add(
+                    f"https://developers.{primary_domain}",
+                    "developers_subdomain",
+                    "A developers subdomain often contains API and integration evidence when user docs are sparse.",
+                    gap.gap_code,
+                    0.82,
+                )
+            elif gap.gap_code == "missing_change_surface":
+                add(
+                    f"https://{primary_domain}/changelog",
+                    "changelog",
+                    "Change coverage is missing, so a changelog is the highest-signal source for freshness and release evidence.",
+                    gap.gap_code,
+                    0.88,
+                )
+                add(
+                    f"https://{primary_domain}/release-notes",
+                    "release_notes",
+                    "Release notes are a common alternative when no changelog surface is present.",
+                    gap.gap_code,
+                    0.84,
+                )
+            elif gap.gap_code == "integrations_thin_support":
+                add(
+                    f"https://{primary_domain}/integrations",
+                    "integrations_directory",
+                    "Integration claims are thinly supported, so the integrations directory is the best next source to deepen proof.",
+                    gap.gap_code,
+                    0.86,
+                )
+            elif gap.gap_code == "claims_stale":
+                add(
+                    f"https://{primary_domain}",
+                    "homepage",
+                    "Claims are stale, so the homepage is a good refresh point before recrawling deeper sources.",
+                    gap.gap_code,
+                    0.62,
+                )
+
+        return list(candidates.values())[:max_candidates]

--- a/tests/test_agents_routes.py
+++ b/tests/test_agents_routes.py
@@ -1,0 +1,53 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.contracts.agents import AgentRunSummary, SourcePlannerResponse, SourceProposal
+from packages.core.deps import get_db
+
+
+class DummySourcePlannerAgentService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def plan(self, request):
+        return SourcePlannerResponse(
+            product_id=request.product_id,
+            agent=AgentRunSummary(
+                agent_name="source_planner_agent",
+                strategy_version="source_planner_v1",
+                mode="heuristic_scaffold",
+            ),
+            considered_gap_codes=["missing_docs_surface"],
+            proposals=[
+                SourceProposal(
+                    root_url="https://docs.example.com",
+                    source_type="docs_subdomain",
+                    reason="Docs coverage is missing.",
+                    target_gap_codes=["missing_docs_surface"],
+                    confidence=0.9,
+                )
+            ],
+        )
+
+
+def override_get_db():
+    yield object()
+
+
+def test_source_planner_agent_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.agents.SourcePlannerAgentService", DummySourcePlannerAgentService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/agents/source-planner/plan",
+        json={"product_id": "00000000-0000-0000-0000-000000000001", "max_candidates": 5},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["agent"]["agent_name"] == "source_planner_agent"
+    assert body["proposals"][0]["root_url"] == "https://docs.example.com"
+    assert body["considered_gap_codes"] == ["missing_docs_surface"]
+
+    app.dependency_overrides.clear()

--- a/tests/test_source_planner_agent.py
+++ b/tests/test_source_planner_agent.py
@@ -1,0 +1,37 @@
+from packages.contracts.product_intelligence import GapItem
+from packages.services.source_planner_agent import SourcePlannerAgentService
+
+
+def test_build_proposals_prioritizes_gap_closure_and_dedupes_existing_sources() -> None:
+    service = SourcePlannerAgentService(db=None)  # type: ignore[arg-type]
+    gaps = [
+        GapItem(
+            gap_code="missing_pricing_page",
+            category="pricing",
+            severity="high",
+            message="Missing pricing page.",
+            evidence_count=0,
+            suggested_source_types=["pricing"],
+        ),
+        GapItem(
+            gap_code="missing_docs_surface",
+            category="docs",
+            severity="high",
+            message="Missing docs surface.",
+            evidence_count=0,
+            suggested_source_types=["docs_subdomain"],
+        ),
+    ]
+
+    proposals = service._build_proposals(
+        primary_domain="example.com",
+        gaps=gaps,
+        existing_sources={"https://example.com/pricing"},
+        include_existing_sources=False,
+        max_candidates=5,
+    )
+
+    urls = [proposal.root_url for proposal in proposals]
+    assert "https://example.com/pricing" not in urls
+    assert "https://docs.example.com" in urls
+    assert any("missing_docs_surface" in proposal.target_gap_codes for proposal in proposals)


### PR DESCRIPTION
## What this ships

Adds the first agent-shaped API surface on top of the tracing substrate.

### Added
- `packages/contracts/agents.py`
- `packages/services/source_planner_agent.py`
- `apps/api/routes/agents.py`
- `tests/test_source_planner_agent.py`
- `tests/test_agents_routes.py`

## Scope
- `POST /v1/agents/source-planner/plan`
- typed request/response contract for source planning
- heuristic scaffold that proposes next best sources from current gap inventory
- trace-aware execution using the tracing substrate from PR-006

## Why now
Research points toward narrow, strongly typed agent surfaces with clear tool boundaries before heavier autonomy. This PR creates the first agent endpoint in that style.
