### PR TITLE
PR-008: add evidence critic agent scaffold

### DIFF
--- a/apps/api/routes/agents.py
+++ b/apps/api/routes/agents.py
@@ -1,9 +1,15 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from packages.contracts.agents import SourcePlannerRequest, SourcePlannerResponse
+from packages.contracts.agents import (
+    EvidenceCriticRequest,
+    EvidenceCriticResponse,
+    SourcePlannerRequest,
+    SourcePlannerResponse,
+)
 from packages.contracts.api_common import ApiEnvelope
 from packages.core.deps import get_db
+from packages.services.evidence_critic_agent import EvidenceCriticAgentService
 from packages.services.source_planner_agent import SourcePlannerAgentService
 
 router = APIRouter(prefix="/v1/agents", tags=["agents"])
@@ -12,4 +18,10 @@ router = APIRouter(prefix="/v1/agents", tags=["agents"])
 @router.post("/source-planner/plan", response_model=ApiEnvelope)
 def plan_sources(payload: SourcePlannerRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
     result: SourcePlannerResponse = SourcePlannerAgentService(db).plan(payload)
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.post("/evidence-critic/critique", response_model=ApiEnvelope)
+def critique_evidence(payload: EvidenceCriticRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: EvidenceCriticResponse = EvidenceCriticAgentService(db).critique(payload)
     return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/agents.py
+++ b/packages/contracts/agents.py
@@ -28,3 +28,26 @@ class SourcePlannerResponse(BaseModel):
     agent: AgentRunSummary
     considered_gap_codes: list[str] = Field(default_factory=list)
     proposals: list[SourceProposal] = Field(default_factory=list)
+
+
+class EvidenceCriticRequest(BaseModel):
+    product_id: str
+    min_confidence: float = Field(default=0.6, ge=0.0, le=1.0)
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class EvidenceCritiqueItem(BaseModel):
+    claim_id: str
+    claim_type: str
+    normalized_key: str
+    display_label: str
+    support_quality: str
+    confidence: float
+    reason: str
+    recommendations: list[str] = Field(default_factory=list)
+
+
+class EvidenceCriticResponse(BaseModel):
+    product_id: str
+    agent: AgentRunSummary
+    critiques: list[EvidenceCritiqueItem] = Field(default_factory=list)

--- a/packages/services/evidence_critic_agent.py
+++ b/packages/services/evidence_critic_agent.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from packages.contracts.agents import (
+    AgentRunSummary,
+    EvidenceCriticRequest,
+    EvidenceCriticResponse,
+    EvidenceCritiqueItem,
+)
+from packages.observability.tracing import log_event, traced_span
+from packages.services.product_intelligence import ProductIntelligenceService
+
+STRATEGY_VERSION = "evidence_critic_v1"
+
+
+class EvidenceCriticAgentService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.product_intelligence = ProductIntelligenceService(db)
+
+    def critique(self, request: EvidenceCriticRequest) -> EvidenceCriticResponse:
+        product_id = uuid.UUID(request.product_id)
+        with traced_span("agent.evidence_critic.critique", product_id=request.product_id):
+            claims_response = self.product_intelligence.get_product_claims(
+                product_id,
+                min_confidence=request.min_confidence,
+                include_stale=True,
+                include_evidence=True,
+            )
+            critiques = [self._critique_claim(claim) for claim in claims_response.items[: request.limit]]
+            log_event(
+                "agent.evidence_critic.completed",
+                product_id=request.product_id,
+                critique_count=len(critiques),
+            )
+            return EvidenceCriticResponse(
+                product_id=request.product_id,
+                agent=AgentRunSummary(
+                    agent_name="evidence_critic_agent",
+                    strategy_version=STRATEGY_VERSION,
+                    mode="heuristic_scaffold",
+                ),
+                critiques=critiques,
+            )
+
+    def _critique_claim(self, claim) -> EvidenceCritiqueItem:
+        support_quality = "strong"
+        reason_parts: list[str] = []
+        recommendations: list[str] = []
+
+        if "stale" in claim.flags:
+            support_quality = "weak"
+            reason_parts.append("Claim support is stale.")
+            recommendations.append("Recrawl the primary source and changelog surfaces.")
+        if claim.source_count <= 1:
+            support_quality = "thin"
+            reason_parts.append("Claim is supported by only one source.")
+            recommendations.append("Find a second confirming source, ideally docs or API reference.")
+        if not claim.evidence:
+            support_quality = "weak"
+            reason_parts.append("No evidence excerpts were returned in the current payload.")
+            recommendations.append("Request the claim with include_evidence enabled for manual review.")
+        if "docs_backed" in claim.flags and claim.source_count > 1 and "stale" not in claim.flags:
+            reason_parts.append("Claim is backed by docs-like evidence and multiple sources.")
+            if support_quality == "strong":
+                recommendations.append("No immediate action needed.")
+
+        if not reason_parts:
+            reason_parts.append("Claim support is adequate but should still be periodically refreshed.")
+            recommendations.append("Monitor for freshness drift.")
+
+        return EvidenceCritiqueItem(
+            claim_id=claim.claim_id,
+            claim_type=claim.claim_type,
+            normalized_key=claim.normalized_key,
+            display_label=claim.display_label,
+            support_quality=support_quality,
+            confidence=claim.confidence,
+            reason=" ".join(reason_parts),
+            recommendations=recommendations,
+        )

--- a/tests/test_agents_routes.py
+++ b/tests/test_agents_routes.py
@@ -1,7 +1,13 @@
 from fastapi.testclient import TestClient
 
 from apps.api.main import app
-from packages.contracts.agents import AgentRunSummary, SourcePlannerResponse, SourceProposal
+from packages.contracts.agents import (
+    AgentRunSummary,
+    EvidenceCriticResponse,
+    EvidenceCritiqueItem,
+    SourcePlannerResponse,
+    SourceProposal,
+)
 from packages.core.deps import get_db
 
 
@@ -30,6 +36,33 @@ class DummySourcePlannerAgentService:
         )
 
 
+class DummyEvidenceCriticAgentService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def critique(self, request):
+        return EvidenceCriticResponse(
+            product_id=request.product_id,
+            agent=AgentRunSummary(
+                agent_name="evidence_critic_agent",
+                strategy_version="evidence_critic_v1",
+                mode="heuristic_scaffold",
+            ),
+            critiques=[
+                EvidenceCritiqueItem(
+                    claim_id="capability:single_sign_on",
+                    claim_type="capability",
+                    normalized_key="single_sign_on",
+                    display_label="Single Sign-On",
+                    support_quality="thin",
+                    confidence=0.82,
+                    reason="Claim is supported by only one source.",
+                    recommendations=["Find a second confirming source, ideally docs or API reference."],
+                )
+            ],
+        )
+
+
 def override_get_db():
     yield object()
 
@@ -49,5 +82,24 @@ def test_source_planner_agent_endpoint_returns_payload(monkeypatch) -> None:
     assert body["agent"]["agent_name"] == "source_planner_agent"
     assert body["proposals"][0]["root_url"] == "https://docs.example.com"
     assert body["considered_gap_codes"] == ["missing_docs_surface"]
+
+    app.dependency_overrides.clear()
+
+
+def test_evidence_critic_agent_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.agents.EvidenceCriticAgentService", DummyEvidenceCriticAgentService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/agents/evidence-critic/critique",
+        json={"product_id": "00000000-0000-0000-0000-000000000001", "min_confidence": 0.6, "limit": 5},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["agent"]["agent_name"] == "evidence_critic_agent"
+    assert body["critiques"][0]["support_quality"] == "thin"
+    assert body["critiques"][0]["normalized_key"] == "single_sign_on"
 
     app.dependency_overrides.clear()

--- a/tests/test_evidence_critic_agent.py
+++ b/tests/test_evidence_critic_agent.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+
+from packages.contracts.claims import ClaimEvidenceRef, NormalizedClaim
+from packages.services.evidence_critic_agent import EvidenceCriticAgentService
+
+
+def _claim(*, claim_id: str, flags: list[str], source_count: int, include_evidence: bool) -> NormalizedClaim:
+    evidence = []
+    if include_evidence:
+        evidence = [
+            ClaimEvidenceRef(
+                evidence_id="e1",
+                page_id="p1",
+                source_id="s1",
+                canonical_url="https://docs.example.com",
+                page_type="docs",
+                snippet="Supports SSO.",
+                confidence=0.82,
+                created_at=datetime.now(timezone.utc),
+            )
+        ]
+    return NormalizedClaim(
+        claim_id=claim_id,
+        claim_type="capability",
+        normalized_key="single_sign_on",
+        display_label="Single Sign-On",
+        confidence=0.82,
+        support_count=1,
+        source_count=source_count,
+        page_count=1,
+        freshness_score=1.0,
+        latest_evidence_at=datetime.now(timezone.utc),
+        flags=flags,
+        evidence=evidence,
+    )
+
+
+def test_critique_claim_marks_thin_or_stale_support() -> None:
+    service = EvidenceCriticAgentService(db=None)  # type: ignore[arg-type]
+
+    thin_claim = _claim(claim_id="c1", flags=[], source_count=1, include_evidence=True)
+    stale_claim = _claim(claim_id="c2", flags=["stale"], source_count=2, include_evidence=False)
+
+    thin_result = service._critique_claim(thin_claim)
+    stale_result = service._critique_claim(stale_claim)
+
+    assert thin_result.support_quality == "thin"
+    assert "one source" in thin_result.reason.lower()
+    assert stale_result.support_quality == "weak"
+    assert any("include_evidence" in recommendation for recommendation in stale_result.recommendations)


### PR DESCRIPTION
## What this ships

Adds the second narrow agent surface on top of the tracing substrate and source planner scaffold.

### Added
- `packages/services/evidence_critic_agent.py`
- `packages/contracts/agents.py` updates for evidence critic request/response shapes
- `apps/api/routes/agents.py` updates to expose evidence critic endpoint
- `tests/test_evidence_critic_agent.py`
- `tests/test_agents_routes.py` updates to cover the new endpoint

## Scope
- `POST /v1/agents/evidence-critic/critique`
- typed critique output for current claim support quality
- heuristic scaffold that flags thin support, stale support, and missing evidence excerpts
- trace-aware execution using the existing tracing substrate

## Why now
This pairs naturally with the source planner: one agent proposes what to crawl next, the other critiques whether current evidence is actually strong enough.
