### PR TITLE
PR-009: add agent evaluator scaffold

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from apps.api.routes.admin import router as admin_router
+from apps.api.routes.agent_evals import router as agent_evals_router
 from apps.api.routes.agents import router as agents_router
 from apps.api.routes.compare import router as compare_router
 from apps.api.routes.products import router as products_router
@@ -17,6 +18,7 @@ app.add_middleware(RequestTracingMiddleware)
 
 app.include_router(vendors_router)
 app.include_router(admin_router)
+app.include_router(agent_evals_router)
 app.include_router(products_router)
 app.include_router(compare_router)
 app.include_router(agents_router)

--- a/apps/api/routes/agent_evals.py
+++ b/apps/api/routes/agent_evals.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from packages.contracts.agent_evals import AgentEvalRequest, AgentEvalResponse
+from packages.contracts.api_common import ApiEnvelope
+from packages.core.deps import get_db
+from packages.services.agent_evaluator import AgentEvaluatorService
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+@router.post("/agent-evals/run", response_model=ApiEnvelope)
+def run_agent_eval(payload: AgentEvalRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: AgentEvalResponse = AgentEvaluatorService().evaluate(payload)
+    return ApiEnvelope(data=result.model_dump())

--- a/apps/api/routes/agents.py
+++ b/apps/api/routes/agents.py
@@ -1,9 +1,15 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from packages.contracts.agents import SourcePlannerRequest, SourcePlannerResponse
+from packages.contracts.agents import (
+    EvidenceCriticRequest,
+    EvidenceCriticResponse,
+    SourcePlannerRequest,
+    SourcePlannerResponse,
+)
 from packages.contracts.api_common import ApiEnvelope
 from packages.core.deps import get_db
+from packages.services.evidence_critic_agent import EvidenceCriticAgentService
 from packages.services.source_planner_agent import SourcePlannerAgentService
 
 router = APIRouter(prefix="/v1/agents", tags=["agents"])
@@ -12,4 +18,10 @@ router = APIRouter(prefix="/v1/agents", tags=["agents"])
 @router.post("/source-planner/plan", response_model=ApiEnvelope)
 def plan_sources(payload: SourcePlannerRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
     result: SourcePlannerResponse = SourcePlannerAgentService(db).plan(payload)
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.post("/evidence-critic/critique", response_model=ApiEnvelope)
+def critique_evidence(payload: EvidenceCriticRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: EvidenceCriticResponse = EvidenceCriticAgentService(db).critique(payload)
     return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/agent_evals.py
+++ b/packages/contracts/agent_evals.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+
+
+class AgentEvalRequest(BaseModel):
+    agent_name: str
+    payload: dict = Field(default_factory=dict)
+
+
+class AgentEvalCheck(BaseModel):
+    check_name: str
+    passed: bool
+    severity: str
+    message: str
+
+
+class AgentEvalScorecard(BaseModel):
+    overall_passed: bool
+    passed_checks: int
+    failed_checks: int
+    score: float = Field(ge=0.0, le=1.0)
+
+
+class AgentEvalResponse(BaseModel):
+    agent_name: str
+    evaluator_version: str
+    scorecard: AgentEvalScorecard
+    checks: list[AgentEvalCheck] = Field(default_factory=list)

--- a/packages/contracts/agents.py
+++ b/packages/contracts/agents.py
@@ -28,3 +28,26 @@ class SourcePlannerResponse(BaseModel):
     agent: AgentRunSummary
     considered_gap_codes: list[str] = Field(default_factory=list)
     proposals: list[SourceProposal] = Field(default_factory=list)
+
+
+class EvidenceCriticRequest(BaseModel):
+    product_id: str
+    min_confidence: float = Field(default=0.6, ge=0.0, le=1.0)
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class EvidenceCritiqueItem(BaseModel):
+    claim_id: str
+    claim_type: str
+    normalized_key: str
+    display_label: str
+    support_quality: str
+    confidence: float
+    reason: str
+    recommendations: list[str] = Field(default_factory=list)
+
+
+class EvidenceCriticResponse(BaseModel):
+    product_id: str
+    agent: AgentRunSummary
+    critiques: list[EvidenceCritiqueItem] = Field(default_factory=list)

--- a/packages/services/agent_evaluator.py
+++ b/packages/services/agent_evaluator.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from packages.contracts.agent_evals import (
+    AgentEvalCheck,
+    AgentEvalRequest,
+    AgentEvalResponse,
+    AgentEvalScorecard,
+)
+from packages.observability.tracing import log_event, traced_span
+
+EVALUATOR_VERSION = "agent_evaluator_v1"
+_ALLOWED_SUPPORT_QUALITIES = {"strong", "thin", "weak"}
+
+
+class AgentEvaluatorService:
+    def evaluate(self, request: AgentEvalRequest) -> AgentEvalResponse:
+        with traced_span("agent_evaluator.evaluate", agent_name=request.agent_name):
+            if request.agent_name == "source_planner_agent":
+                checks = self._evaluate_source_planner_payload(request.payload)
+            elif request.agent_name == "evidence_critic_agent":
+                checks = self._evaluate_evidence_critic_payload(request.payload)
+            else:
+                checks = [
+                    AgentEvalCheck(
+                        check_name="known_agent",
+                        passed=False,
+                        severity="high",
+                        message=f"No evaluator is registered for agent '{request.agent_name}'.",
+                    )
+                ]
+
+            failed_checks = len([check for check in checks if not check.passed])
+            passed_checks = len(checks) - failed_checks
+            overall_passed = failed_checks == 0
+            score = round(passed_checks / len(checks), 3) if checks else 0.0
+            log_event(
+                "agent_evaluator.completed",
+                agent_name=request.agent_name,
+                passed_checks=passed_checks,
+                failed_checks=failed_checks,
+                score=score,
+            )
+            return AgentEvalResponse(
+                agent_name=request.agent_name,
+                evaluator_version=EVALUATOR_VERSION,
+                scorecard=AgentEvalScorecard(
+                    overall_passed=overall_passed,
+                    passed_checks=passed_checks,
+                    failed_checks=failed_checks,
+                    score=score,
+                ),
+                checks=checks,
+            )
+
+    def _evaluate_source_planner_payload(self, payload: dict) -> list[AgentEvalCheck]:
+        proposals = payload.get("proposals") or []
+        considered_gap_codes = payload.get("considered_gap_codes") or []
+
+        checks = [
+            AgentEvalCheck(
+                check_name="has_proposals",
+                passed=len(proposals) > 0,
+                severity="medium",
+                message="Source planner should usually return at least one proposal.",
+            ),
+            AgentEvalCheck(
+                check_name="proposal_reasons_present",
+                passed=all(bool(proposal.get("reason")) for proposal in proposals),
+                severity="medium",
+                message="Every proposal should include a human-readable reason.",
+            ),
+            AgentEvalCheck(
+                check_name="proposal_confidence_in_range",
+                passed=all(0.0 <= float(proposal.get("confidence", -1)) <= 1.0 for proposal in proposals),
+                severity="high",
+                message="Every proposal confidence should be between 0.0 and 1.0.",
+            ),
+            AgentEvalCheck(
+                check_name="proposal_urls_unique",
+                passed=len({proposal.get("root_url") for proposal in proposals}) == len(proposals),
+                severity="medium",
+                message="Proposals should not contain duplicate root URLs.",
+            ),
+            AgentEvalCheck(
+                check_name="gap_coverage_present",
+                passed=len(considered_gap_codes) > 0,
+                severity="low",
+                message="Source planner output should disclose the gap codes it considered.",
+            ),
+        ]
+        return checks
+
+    def _evaluate_evidence_critic_payload(self, payload: dict) -> list[AgentEvalCheck]:
+        critiques = payload.get("critiques") or []
+
+        checks = [
+            AgentEvalCheck(
+                check_name="has_critiques",
+                passed=len(critiques) > 0,
+                severity="medium",
+                message="Evidence critic should usually return at least one critique item.",
+            ),
+            AgentEvalCheck(
+                check_name="support_quality_valid",
+                passed=all(critique.get("support_quality") in _ALLOWED_SUPPORT_QUALITIES for critique in critiques),
+                severity="high",
+                message="Support quality should be one of strong, thin, or weak.",
+            ),
+            AgentEvalCheck(
+                check_name="reasons_present",
+                passed=all(bool(critique.get("reason")) for critique in critiques),
+                severity="medium",
+                message="Every critique should include a reason.",
+            ),
+            AgentEvalCheck(
+                check_name="recommendations_present",
+                passed=all(len(critique.get("recommendations") or []) > 0 for critique in critiques),
+                severity="low",
+                message="Every critique should include at least one recommendation.",
+            ),
+            AgentEvalCheck(
+                check_name="confidence_in_range",
+                passed=all(0.0 <= float(critique.get("confidence", -1)) <= 1.0 for critique in critiques),
+                severity="high",
+                message="Every critique confidence should be between 0.0 and 1.0.",
+            ),
+        ]
+        return checks

--- a/packages/services/evidence_critic_agent.py
+++ b/packages/services/evidence_critic_agent.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from packages.contracts.agents import (
+    AgentRunSummary,
+    EvidenceCriticRequest,
+    EvidenceCriticResponse,
+    EvidenceCritiqueItem,
+)
+from packages.observability.tracing import log_event, traced_span
+from packages.services.product_intelligence import ProductIntelligenceService
+
+STRATEGY_VERSION = "evidence_critic_v1"
+
+
+class EvidenceCriticAgentService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.product_intelligence = ProductIntelligenceService(db)
+
+    def critique(self, request: EvidenceCriticRequest) -> EvidenceCriticResponse:
+        product_id = uuid.UUID(request.product_id)
+        with traced_span("agent.evidence_critic.critique", product_id=request.product_id):
+            claims_response = self.product_intelligence.get_product_claims(
+                product_id,
+                min_confidence=request.min_confidence,
+                include_stale=True,
+                include_evidence=True,
+            )
+            critiques = [self._critique_claim(claim) for claim in claims_response.items[: request.limit]]
+            log_event(
+                "agent.evidence_critic.completed",
+                product_id=request.product_id,
+                critique_count=len(critiques),
+            )
+            return EvidenceCriticResponse(
+                product_id=request.product_id,
+                agent=AgentRunSummary(
+                    agent_name="evidence_critic_agent",
+                    strategy_version=STRATEGY_VERSION,
+                    mode="heuristic_scaffold",
+                ),
+                critiques=critiques,
+            )
+
+    def _critique_claim(self, claim) -> EvidenceCritiqueItem:
+        support_quality = "strong"
+        reason_parts: list[str] = []
+        recommendations: list[str] = []
+
+        if "stale" in claim.flags:
+            support_quality = "weak"
+            reason_parts.append("Claim support is stale.")
+            recommendations.append("Recrawl the primary source and changelog surfaces.")
+        if claim.source_count <= 1:
+            support_quality = "thin"
+            reason_parts.append("Claim is supported by only one source.")
+            recommendations.append("Find a second confirming source, ideally docs or API reference.")
+        if not claim.evidence:
+            support_quality = "weak"
+            reason_parts.append("No evidence excerpts were returned in the current payload.")
+            recommendations.append("Request the claim with include_evidence enabled for manual review.")
+        if "docs_backed" in claim.flags and claim.source_count > 1 and "stale" not in claim.flags:
+            reason_parts.append("Claim is backed by docs-like evidence and multiple sources.")
+            if support_quality == "strong":
+                recommendations.append("No immediate action needed.")
+
+        if not reason_parts:
+            reason_parts.append("Claim support is adequate but should still be periodically refreshed.")
+            recommendations.append("Monitor for freshness drift.")
+
+        return EvidenceCritiqueItem(
+            claim_id=claim.claim_id,
+            claim_type=claim.claim_type,
+            normalized_key=claim.normalized_key,
+            display_label=claim.display_label,
+            support_quality=support_quality,
+            confidence=claim.confidence,
+            reason=" ".join(reason_parts),
+            recommendations=recommendations,
+        )

--- a/tests/test_agent_eval_routes.py
+++ b/tests/test_agent_eval_routes.py
@@ -1,0 +1,62 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.contracts.agent_evals import AgentEvalCheck, AgentEvalResponse, AgentEvalScorecard
+from packages.core.deps import get_db
+
+
+class DummyAgentEvaluatorService:
+    def evaluate(self, payload):
+        return AgentEvalResponse(
+            agent_name=payload.agent_name,
+            evaluator_version="agent_evaluator_v1",
+            scorecard=AgentEvalScorecard(
+                overall_passed=True,
+                passed_checks=3,
+                failed_checks=0,
+                score=1.0,
+            ),
+            checks=[
+                AgentEvalCheck(
+                    check_name="has_proposals",
+                    passed=True,
+                    severity="medium",
+                    message="ok",
+                )
+            ],
+        )
+
+
+def override_get_db():
+    yield object()
+
+
+def test_admin_agent_eval_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.agent_evals.AgentEvaluatorService", lambda: DummyAgentEvaluatorService())
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/admin/agent-evals/run",
+        json={
+            "agent_name": "source_planner_agent",
+            "payload": {
+                "proposals": [
+                    {
+                        "root_url": "https://docs.example.com",
+                        "source_type": "docs_subdomain",
+                        "reason": "Docs coverage is missing.",
+                        "confidence": 0.9,
+                    }
+                ],
+                "considered_gap_codes": ["missing_docs_surface"],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["agent_name"] == "source_planner_agent"
+    assert body["scorecard"]["overall_passed"] is True
+
+    app.dependency_overrides.clear()

--- a/tests/test_agent_evaluator.py
+++ b/tests/test_agent_evaluator.py
@@ -1,0 +1,55 @@
+from packages.contracts.agent_evals import AgentEvalRequest
+from packages.services.agent_evaluator import AgentEvaluatorService
+
+
+def test_evaluate_source_planner_payload_scores_expected_checks() -> None:
+    service = AgentEvaluatorService()
+
+    response = service.evaluate(
+        AgentEvalRequest(
+            agent_name="source_planner_agent",
+            payload={
+                "considered_gap_codes": ["missing_docs_surface"],
+                "proposals": [
+                    {
+                        "root_url": "https://docs.example.com",
+                        "source_type": "docs_subdomain",
+                        "reason": "Docs coverage is missing.",
+                        "confidence": 0.9,
+                    }
+                ],
+            },
+        )
+    )
+
+    assert response.agent_name == "source_planner_agent"
+    assert response.scorecard.failed_checks == 0
+    assert response.scorecard.overall_passed is True
+
+
+def test_evaluate_evidence_critic_payload_flags_missing_recommendations() -> None:
+    service = AgentEvaluatorService()
+
+    response = service.evaluate(
+        AgentEvalRequest(
+            agent_name="evidence_critic_agent",
+            payload={
+                "critiques": [
+                    {
+                        "claim_id": "capability:single_sign_on",
+                        "claim_type": "capability",
+                        "normalized_key": "single_sign_on",
+                        "display_label": "Single Sign-On",
+                        "support_quality": "thin",
+                        "confidence": 0.82,
+                        "reason": "Only one source supports this claim.",
+                        "recommendations": [],
+                    }
+                ]
+            },
+        )
+    )
+
+    assert response.agent_name == "evidence_critic_agent"
+    assert response.scorecard.failed_checks >= 1
+    assert any(check.check_name == "recommendations_present" and not check.passed for check in response.checks)

--- a/tests/test_agents_routes.py
+++ b/tests/test_agents_routes.py
@@ -1,7 +1,13 @@
 from fastapi.testclient import TestClient
 
 from apps.api.main import app
-from packages.contracts.agents import AgentRunSummary, SourcePlannerResponse, SourceProposal
+from packages.contracts.agents import (
+    AgentRunSummary,
+    EvidenceCriticResponse,
+    EvidenceCritiqueItem,
+    SourcePlannerResponse,
+    SourceProposal,
+)
 from packages.core.deps import get_db
 
 
@@ -30,6 +36,33 @@ class DummySourcePlannerAgentService:
         )
 
 
+class DummyEvidenceCriticAgentService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def critique(self, request):
+        return EvidenceCriticResponse(
+            product_id=request.product_id,
+            agent=AgentRunSummary(
+                agent_name="evidence_critic_agent",
+                strategy_version="evidence_critic_v1",
+                mode="heuristic_scaffold",
+            ),
+            critiques=[
+                EvidenceCritiqueItem(
+                    claim_id="capability:single_sign_on",
+                    claim_type="capability",
+                    normalized_key="single_sign_on",
+                    display_label="Single Sign-On",
+                    support_quality="thin",
+                    confidence=0.82,
+                    reason="Claim is supported by only one source.",
+                    recommendations=["Find a second confirming source, ideally docs or API reference."],
+                )
+            ],
+        )
+
+
 def override_get_db():
     yield object()
 
@@ -49,5 +82,24 @@ def test_source_planner_agent_endpoint_returns_payload(monkeypatch) -> None:
     assert body["agent"]["agent_name"] == "source_planner_agent"
     assert body["proposals"][0]["root_url"] == "https://docs.example.com"
     assert body["considered_gap_codes"] == ["missing_docs_surface"]
+
+    app.dependency_overrides.clear()
+
+
+def test_evidence_critic_agent_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.agents.EvidenceCriticAgentService", DummyEvidenceCriticAgentService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/agents/evidence-critic/critique",
+        json={"product_id": "00000000-0000-0000-0000-000000000001", "min_confidence": 0.6, "limit": 5},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["agent"]["agent_name"] == "evidence_critic_agent"
+    assert body["critiques"][0]["support_quality"] == "thin"
+    assert body["critiques"][0]["normalized_key"] == "single_sign_on"
 
     app.dependency_overrides.clear()

--- a/tests/test_evidence_critic_agent.py
+++ b/tests/test_evidence_critic_agent.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+
+from packages.contracts.claims import ClaimEvidenceRef, NormalizedClaim
+from packages.services.evidence_critic_agent import EvidenceCriticAgentService
+
+
+def _claim(*, claim_id: str, flags: list[str], source_count: int, include_evidence: bool) -> NormalizedClaim:
+    evidence = []
+    if include_evidence:
+        evidence = [
+            ClaimEvidenceRef(
+                evidence_id="e1",
+                page_id="p1",
+                source_id="s1",
+                canonical_url="https://docs.example.com",
+                page_type="docs",
+                snippet="Supports SSO.",
+                confidence=0.82,
+                created_at=datetime.now(timezone.utc),
+            )
+        ]
+    return NormalizedClaim(
+        claim_id=claim_id,
+        claim_type="capability",
+        normalized_key="single_sign_on",
+        display_label="Single Sign-On",
+        confidence=0.82,
+        support_count=1,
+        source_count=source_count,
+        page_count=1,
+        freshness_score=1.0,
+        latest_evidence_at=datetime.now(timezone.utc),
+        flags=flags,
+        evidence=evidence,
+    )
+
+
+def test_critique_claim_marks_thin_or_stale_support() -> None:
+    service = EvidenceCriticAgentService(db=None)  # type: ignore[arg-type]
+
+    thin_claim = _claim(claim_id="c1", flags=[], source_count=1, include_evidence=True)
+    stale_claim = _claim(claim_id="c2", flags=["stale"], source_count=2, include_evidence=False)
+
+    thin_result = service._critique_claim(thin_claim)
+    stale_result = service._critique_claim(stale_claim)
+
+    assert thin_result.support_quality == "thin"
+    assert "one source" in thin_result.reason.lower()
+    assert stale_result.support_quality == "weak"
+    assert any("include_evidence" in recommendation for recommendation in stale_result.recommendations)


### PR DESCRIPTION
## What this ships

Adds the first evaluator scaffold for narrow agent surfaces.

### Added
- `packages/contracts/agent_evals.py`
- `packages/services/agent_evaluator.py`
- `apps/api/routes/agent_evals.py`
- `tests/test_agent_evaluator.py`
- `tests/test_agent_eval_routes.py`

### Also included in this branch
- evidence critic scaffold (`packages/services/evidence_critic_agent.py` and supporting route/contract/test updates)

## Scope
- `POST /v1/admin/agent-evals/run`
- deterministic rubric checks for `source_planner_agent` and `evidence_critic_agent`
- typed evaluator scorecard output
- trace-aware execution for eval runs

## Why now
This gives the agent layer a way to be graded systematically before we add heavier autonomy or persistence.
