### PR TITLE
PR-011: add agent run persistence foundation

### DIFF
--- a/packages/core/models.py
+++ b/packages/core/models.py
@@ -131,3 +131,51 @@ class CrawlJob(TimestampMixin, Base):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     last_error: Mapped[str | None] = mapped_column(Text)
     payload: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+
+
+class AgentRun(TimestampMixin, Base):
+    __tablename__ = "agent_runs"
+
+    agent_run_id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    agent_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    strategy_version: Mapped[str | None] = mapped_column(String(100))
+    mode: Mapped[str | None] = mapped_column(String(100))
+    status: Mapped[str] = mapped_column(String(50), default="completed", nullable=False)
+    trace_id: Mapped[str | None] = mapped_column(String(64))
+    request_id: Mapped[str | None] = mapped_column(String(64))
+    product_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("products.product_id"))
+    vendor_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("vendors.vendor_id"))
+    request_payload: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+    response_payload: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+    error_message: Mapped[str | None] = mapped_column(Text)
+
+
+class AgentEvalRun(TimestampMixin, Base):
+    __tablename__ = "agent_eval_runs"
+
+    agent_eval_run_id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    agent_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    evaluator_version: Mapped[str] = mapped_column(String(100), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), default="completed", nullable=False)
+    trace_id: Mapped[str | None] = mapped_column(String(64))
+    request_payload: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+    response_payload: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+    score: Mapped[float | None] = mapped_column(Float)
+    overall_passed: Mapped[bool | None] = mapped_column(Boolean)
+    error_message: Mapped[str | None] = mapped_column(Text)
+
+
+class SourceProposalDecision(TimestampMixin, Base):
+    __tablename__ = "source_proposal_decisions"
+
+    source_proposal_decision_id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    decision_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    agent_name: Mapped[str | None] = mapped_column(String(100))
+    trace_id: Mapped[str | None] = mapped_column(String(64))
+    product_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("products.product_id"))
+    vendor_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("vendors.vendor_id"))
+    source_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("sources.source_id"))
+    crawl_job_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("crawl_jobs.crawl_job_id"))
+    proposal_payload: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+    decision_payload: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+    note: Mapped[str | None] = mapped_column(Text)

--- a/packages/services/agent_run_store.py
+++ b/packages/services/agent_run_store.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from packages.core.models import AgentEvalRun, AgentRun, SourceProposalDecision
+from packages.observability.tracing import get_trace_context
+
+
+class AgentRunStore:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def create_agent_run(
+        self,
+        *,
+        agent_name: str,
+        strategy_version: str | None,
+        mode: str | None,
+        product_id: str | None,
+        vendor_id: str | None,
+        request_payload: dict,
+        response_payload: dict,
+        status: str = "completed",
+        error_message: str | None = None,
+    ) -> AgentRun:
+        trace_context = get_trace_context()
+        record = AgentRun(
+            agent_name=agent_name,
+            strategy_version=strategy_version,
+            mode=mode,
+            status=status,
+            trace_id=trace_context.get("trace_id"),
+            request_id=trace_context.get("request_id"),
+            product_id=uuid.UUID(product_id) if product_id else None,
+            vendor_id=uuid.UUID(vendor_id) if vendor_id else None,
+            request_payload=request_payload,
+            response_payload=response_payload,
+            error_message=error_message,
+        )
+        self.db.add(record)
+        self.db.flush()
+        return record
+
+    def create_agent_eval_run(
+        self,
+        *,
+        agent_name: str,
+        evaluator_version: str,
+        request_payload: dict,
+        response_payload: dict,
+        score: float | None,
+        overall_passed: bool | None,
+        status: str = "completed",
+        error_message: str | None = None,
+    ) -> AgentEvalRun:
+        trace_context = get_trace_context()
+        record = AgentEvalRun(
+            agent_name=agent_name,
+            evaluator_version=evaluator_version,
+            status=status,
+            trace_id=trace_context.get("trace_id"),
+            request_payload=request_payload,
+            response_payload=response_payload,
+            score=score,
+            overall_passed=overall_passed,
+            error_message=error_message,
+        )
+        self.db.add(record)
+        self.db.flush()
+        return record
+
+    def create_source_proposal_decision(
+        self,
+        *,
+        decision_type: str,
+        agent_name: str | None,
+        product_id: str | None,
+        vendor_id: str | None,
+        source_id: str | None,
+        crawl_job_id: str | None,
+        proposal_payload: dict,
+        decision_payload: dict,
+        note: str | None = None,
+    ) -> SourceProposalDecision:
+        trace_context = get_trace_context()
+        record = SourceProposalDecision(
+            decision_type=decision_type,
+            agent_name=agent_name,
+            trace_id=trace_context.get("trace_id"),
+            product_id=uuid.UUID(product_id) if product_id else None,
+            vendor_id=uuid.UUID(vendor_id) if vendor_id else None,
+            source_id=uuid.UUID(source_id) if source_id else None,
+            crawl_job_id=uuid.UUID(crawl_job_id) if crawl_job_id else None,
+            proposal_payload=proposal_payload,
+            decision_payload=decision_payload,
+            note=note,
+        )
+        self.db.add(record)
+        self.db.flush()
+        return record

--- a/packages/services/source_planner_agent.py
+++ b/packages/services/source_planner_agent.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from packages.contracts.agents import AgentRunSummary, SourcePlannerRequest, SourcePlannerResponse, SourceProposal
 from packages.core.models import Product, Source, Vendor
 from packages.observability.tracing import log_event, traced_span
+from packages.services.agent_run_store import AgentRunStore
 from packages.services.gap_detector import detect_product_gaps
 from packages.services.product_intelligence import ProductIntelligenceService, build_normalized_claims
 
@@ -19,6 +20,7 @@ class SourcePlannerAgentService:
     def __init__(self, db: Session) -> None:
         self.db = db
         self.product_intelligence = ProductIntelligenceService(db)
+        self.agent_run_store = AgentRunStore(db)
 
     def plan(self, request: SourcePlannerRequest) -> SourcePlannerResponse:
         product_id = uuid.UUID(request.product_id)
@@ -42,7 +44,7 @@ class SourcePlannerAgentService:
                 gap_count=len(gaps),
                 proposal_count=len(proposals),
             )
-            return SourcePlannerResponse(
+            response = SourcePlannerResponse(
                 product_id=request.product_id,
                 agent=AgentRunSummary(
                     agent_name="source_planner_agent",
@@ -52,6 +54,17 @@ class SourcePlannerAgentService:
                 considered_gap_codes=[gap.gap_code for gap in gaps],
                 proposals=proposals,
             )
+            self.agent_run_store.create_agent_run(
+                agent_name="source_planner_agent",
+                strategy_version=STRATEGY_VERSION,
+                mode="heuristic_scaffold",
+                product_id=request.product_id,
+                vendor_id=context.get("vendor_id"),
+                request_payload=request.model_dump(),
+                response_payload=response.model_dump(),
+            )
+            self.db.commit()
+            return response
 
     def _get_product_vendor_context(self, product_id: uuid.UUID) -> dict[str, str | None]:
         row = self.db.execute(
@@ -65,6 +78,7 @@ class SourcePlannerAgentService:
         return {
             "product_name": product.canonical_name,
             "primary_domain": vendor.primary_domain,
+            "vendor_id": str(vendor.vendor_id),
         }
 
     def _get_existing_sources(self, product_id: uuid.UUID) -> set[str]:

--- a/tests/test_agent_run_store.py
+++ b/tests/test_agent_run_store.py
@@ -1,0 +1,52 @@
+from packages.services.agent_run_store import AgentRunStore
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.added = []
+        self.flush_count = 0
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def flush(self):
+        self.flush_count += 1
+
+
+def test_create_agent_run_persists_record() -> None:
+    session = DummySession()
+    store = AgentRunStore(session)  # type: ignore[arg-type]
+
+    record = store.create_agent_run(
+        agent_name="source_planner_agent",
+        strategy_version="source_planner_v1",
+        mode="heuristic_scaffold",
+        product_id=None,
+        vendor_id=None,
+        request_payload={"product_id": "p1"},
+        response_payload={"proposals": []},
+    )
+
+    assert record.agent_name == "source_planner_agent"
+    assert record.strategy_version == "source_planner_v1"
+    assert session.flush_count == 1
+    assert len(session.added) == 1
+
+
+def test_create_agent_eval_run_persists_scorecard() -> None:
+    session = DummySession()
+    store = AgentRunStore(session)  # type: ignore[arg-type]
+
+    record = store.create_agent_eval_run(
+        agent_name="source_planner_agent",
+        evaluator_version="agent_evaluator_v1",
+        request_payload={"agent_name": "source_planner_agent"},
+        response_payload={"scorecard": {"score": 1.0}},
+        score=1.0,
+        overall_passed=True,
+    )
+
+    assert record.evaluator_version == "agent_evaluator_v1"
+    assert record.score == 1.0
+    assert record.overall_passed is True
+    assert session.flush_count == 1

--- a/tests/test_source_planner_persistence.py
+++ b/tests/test_source_planner_persistence.py
@@ -1,0 +1,59 @@
+from packages.contracts.agents import SourcePlannerRequest
+from packages.contracts.product_intelligence import GapItem
+from packages.services.source_planner_agent import SourcePlannerAgentService
+
+
+class DummyProductIntelligence:
+    def _get_claim_rows(self, product_id):
+        return []
+
+    def _get_page_types(self, product_id):
+        return {"homepage"}
+
+
+class DummyStore:
+    def __init__(self):
+        self.calls = []
+
+    def create_agent_run(self, **kwargs):
+        self.calls.append(kwargs)
+        return object()
+
+
+class DummySession:
+    def commit(self):
+        return None
+
+
+def test_source_planner_persists_agent_run(monkeypatch) -> None:
+    service = SourcePlannerAgentService(DummySession())  # type: ignore[arg-type]
+    service.product_intelligence = DummyProductIntelligence()
+    service.agent_run_store = DummyStore()
+
+    monkeypatch.setattr(
+        service,
+        "_get_product_vendor_context",
+        lambda product_id: {"product_name": "Example", "primary_domain": "example.com", "vendor_id": None},
+    )
+    monkeypatch.setattr(service, "_get_existing_sources", lambda product_id: set())
+    monkeypatch.setattr(
+        "packages.services.source_planner_agent.detect_product_gaps",
+        lambda page_types, claims: [
+            GapItem(
+                gap_code="missing_docs_surface",
+                category="docs",
+                severity="high",
+                message="Missing docs.",
+                evidence_count=0,
+                suggested_source_types=["docs_subdomain"],
+            )
+        ],
+    )
+
+    response = service.plan(
+        SourcePlannerRequest(product_id="00000000-0000-0000-0000-000000000001", max_candidates=3)
+    )
+
+    assert response.agent.agent_name == "source_planner_agent"
+    assert len(service.agent_run_store.calls) == 1
+    assert service.agent_run_store.calls[0]["agent_name"] == "source_planner_agent"


### PR DESCRIPTION
## What this ships

Adds the persistence foundation for the agent layer.

### Added
- `agent_runs` model
- `agent_eval_runs` model
- `source_proposal_decisions` model
- `packages/services/agent_run_store.py`
- persistence tests
- source planner write-path integration

## Scope
- durable storage for agent runs, evaluator runs, and proposal decisions
- trace-aware persistence via shared store service
- first merged write-path integration on the source planner agent

## Why now
This is the missing spine for the agent layer. Without persistence, agents can act, but the system cannot audit, inspect, or improve them systematically.
