### PR TITLE
PR-012: harden first operational agent loop

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -5,6 +5,7 @@ from apps.api.routes.agent_evals import router as agent_evals_router
 from apps.api.routes.agents import router as agents_router
 from apps.api.routes.compare import router as compare_router
 from apps.api.routes.products import router as products_router
+from apps.api.routes.source_promotion import router as source_promotion_router
 from apps.api.routes.vendors import router as vendors_router
 from packages.core.config import get_settings
 from packages.observability.middleware import RequestTracingMiddleware
@@ -19,6 +20,7 @@ app.add_middleware(RequestTracingMiddleware)
 app.include_router(vendors_router)
 app.include_router(admin_router)
 app.include_router(agent_evals_router)
+app.include_router(source_promotion_router)
 app.include_router(products_router)
 app.include_router(compare_router)
 app.include_router(agents_router)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from apps.api.routes.admin import router as admin_router
+from apps.api.routes.agent_evals import router as agent_evals_router
 from apps.api.routes.agents import router as agents_router
 from apps.api.routes.compare import router as compare_router
 from apps.api.routes.products import router as products_router
@@ -17,6 +18,7 @@ app.add_middleware(RequestTracingMiddleware)
 
 app.include_router(vendors_router)
 app.include_router(admin_router)
+app.include_router(agent_evals_router)
 app.include_router(products_router)
 app.include_router(compare_router)
 app.include_router(agents_router)

--- a/apps/api/routes/agent_evals.py
+++ b/apps/api/routes/agent_evals.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from packages.contracts.agent_evals import AgentEvalRequest, AgentEvalResponse
+from packages.contracts.api_common import ApiEnvelope
+from packages.core.deps import get_db
+from packages.services.agent_evaluator import AgentEvaluatorService
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+@router.post("/agent-evals/run", response_model=ApiEnvelope)
+def run_agent_eval(payload: AgentEvalRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: AgentEvalResponse = AgentEvaluatorService(db).evaluate(payload)
+    return ApiEnvelope(data=result.model_dump())

--- a/apps/api/routes/agents.py
+++ b/apps/api/routes/agents.py
@@ -1,9 +1,15 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from packages.contracts.agents import SourcePlannerRequest, SourcePlannerResponse
+from packages.contracts.agents import (
+    EvidenceCriticRequest,
+    EvidenceCriticResponse,
+    SourcePlannerRequest,
+    SourcePlannerResponse,
+)
 from packages.contracts.api_common import ApiEnvelope
 from packages.core.deps import get_db
+from packages.services.evidence_critic_agent import EvidenceCriticAgentService
 from packages.services.source_planner_agent import SourcePlannerAgentService
 
 router = APIRouter(prefix="/v1/agents", tags=["agents"])
@@ -12,4 +18,10 @@ router = APIRouter(prefix="/v1/agents", tags=["agents"])
 @router.post("/source-planner/plan", response_model=ApiEnvelope)
 def plan_sources(payload: SourcePlannerRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
     result: SourcePlannerResponse = SourcePlannerAgentService(db).plan(payload)
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.post("/evidence-critic/critique", response_model=ApiEnvelope)
+def critique_evidence(payload: EvidenceCriticRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: EvidenceCriticResponse = EvidenceCriticAgentService(db).critique(payload)
     return ApiEnvelope(data=result.model_dump())

--- a/apps/api/routes/source_promotion.py
+++ b/apps/api/routes/source_promotion.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from packages.contracts.api_common import ApiEnvelope
+from packages.contracts.source_promotion import (
+    PromoteSourceProposalRequest,
+    PromoteSourceProposalResponse,
+    RejectSourceProposalRequest,
+    RejectSourceProposalResponse,
+)
+from packages.core.deps import get_db
+from packages.services.source_promotion import SourcePromotionService
+
+router = APIRouter(prefix="/v1/admin/source-proposals", tags=["admin"])
+
+
+@router.post("/promote", response_model=ApiEnvelope)
+def promote_source_proposal(payload: PromoteSourceProposalRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: PromoteSourceProposalResponse = SourcePromotionService(db).promote(payload)
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.post("/reject", response_model=ApiEnvelope)
+def reject_source_proposal(payload: RejectSourceProposalRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: RejectSourceProposalResponse = SourcePromotionService(db).reject(payload)
+    return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/agent_evals.py
+++ b/packages/contracts/agent_evals.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+
+
+class AgentEvalRequest(BaseModel):
+    agent_name: str
+    payload: dict = Field(default_factory=dict)
+
+
+class AgentEvalCheck(BaseModel):
+    check_name: str
+    passed: bool
+    severity: str
+    message: str
+
+
+class AgentEvalScorecard(BaseModel):
+    overall_passed: bool
+    passed_checks: int
+    failed_checks: int
+    score: float = Field(ge=0.0, le=1.0)
+
+
+class AgentEvalResponse(BaseModel):
+    agent_name: str
+    evaluator_version: str
+    scorecard: AgentEvalScorecard
+    checks: list[AgentEvalCheck] = Field(default_factory=list)

--- a/packages/contracts/agents.py
+++ b/packages/contracts/agents.py
@@ -28,3 +28,26 @@ class SourcePlannerResponse(BaseModel):
     agent: AgentRunSummary
     considered_gap_codes: list[str] = Field(default_factory=list)
     proposals: list[SourceProposal] = Field(default_factory=list)
+
+
+class EvidenceCriticRequest(BaseModel):
+    product_id: str
+    min_confidence: float = Field(default=0.6, ge=0.0, le=1.0)
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class EvidenceCritiqueItem(BaseModel):
+    claim_id: str
+    claim_type: str
+    normalized_key: str
+    display_label: str
+    support_quality: str
+    confidence: float
+    reason: str
+    recommendations: list[str] = Field(default_factory=list)
+
+
+class EvidenceCriticResponse(BaseModel):
+    product_id: str
+    agent: AgentRunSummary
+    critiques: list[EvidenceCritiqueItem] = Field(default_factory=list)

--- a/packages/contracts/source_promotion.py
+++ b/packages/contracts/source_promotion.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, Field
+
+from packages.contracts.agents import SourceProposal
+
+
+class PromoteSourceProposalRequest(BaseModel):
+    product_id: str
+    proposal: SourceProposal
+    create_crawl_job: bool = True
+    crawl_priority: int = Field(default=90, ge=0, le=100)
+    note: str | None = None
+
+
+class PromoteSourceProposalResponse(BaseModel):
+    product_id: str
+    source_id: str
+    crawl_job_id: str | None = None
+    created_source: bool
+    created_crawl_job: bool
+    deduped_existing_source: bool
+
+
+class RejectSourceProposalRequest(BaseModel):
+    product_id: str
+    proposal: SourceProposal
+    reason: str
+
+
+class RejectSourceProposalResponse(BaseModel):
+    product_id: str
+    rejected: bool
+    reason: str
+    proposal_root_url: str

--- a/packages/services/agent_evaluator.py
+++ b/packages/services/agent_evaluator.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from packages.contracts.agent_evals import (
+    AgentEvalCheck,
+    AgentEvalRequest,
+    AgentEvalResponse,
+    AgentEvalScorecard,
+)
+from packages.observability.tracing import log_event, traced_span
+from packages.services.agent_run_store import AgentRunStore
+
+EVALUATOR_VERSION = "agent_evaluator_v1"
+_ALLOWED_SUPPORT_QUALITIES = {"strong", "thin", "weak"}
+
+
+class AgentEvaluatorService:
+    def __init__(self, db=None) -> None:
+        self.db = db
+        self.agent_run_store = AgentRunStore(db) if db is not None else None
+
+    def evaluate(self, request: AgentEvalRequest) -> AgentEvalResponse:
+        with traced_span("agent_evaluator.evaluate", agent_name=request.agent_name):
+            if request.agent_name == "source_planner_agent":
+                checks = self._evaluate_source_planner_payload(request.payload)
+            elif request.agent_name == "evidence_critic_agent":
+                checks = self._evaluate_evidence_critic_payload(request.payload)
+            else:
+                checks = [
+                    AgentEvalCheck(
+                        check_name="known_agent",
+                        passed=False,
+                        severity="high",
+                        message=f"No evaluator is registered for agent '{request.agent_name}'.",
+                    )
+                ]
+
+            failed_checks = len([check for check in checks if not check.passed])
+            passed_checks = len(checks) - failed_checks
+            overall_passed = failed_checks == 0
+            score = round(passed_checks / len(checks), 3) if checks else 0.0
+            log_event(
+                "agent_evaluator.completed",
+                agent_name=request.agent_name,
+                passed_checks=passed_checks,
+                failed_checks=failed_checks,
+                score=score,
+            )
+            response = AgentEvalResponse(
+                agent_name=request.agent_name,
+                evaluator_version=EVALUATOR_VERSION,
+                scorecard=AgentEvalScorecard(
+                    overall_passed=overall_passed,
+                    passed_checks=passed_checks,
+                    failed_checks=failed_checks,
+                    score=score,
+                ),
+                checks=checks,
+            )
+            if self.agent_run_store is not None:
+                self.agent_run_store.create_agent_eval_run(
+                    agent_name=request.agent_name,
+                    evaluator_version=EVALUATOR_VERSION,
+                    request_payload=request.model_dump(),
+                    response_payload=response.model_dump(),
+                    score=score,
+                    overall_passed=overall_passed,
+                )
+                self.db.commit()
+            return response
+
+    def _evaluate_source_planner_payload(self, payload: dict) -> list[AgentEvalCheck]:
+        proposals = payload.get("proposals") or []
+        considered_gap_codes = payload.get("considered_gap_codes") or []
+
+        checks = [
+            AgentEvalCheck(
+                check_name="has_proposals",
+                passed=len(proposals) > 0,
+                severity="medium",
+                message="Source planner should usually return at least one proposal.",
+            ),
+            AgentEvalCheck(
+                check_name="proposal_reasons_present",
+                passed=all(bool(proposal.get("reason")) for proposal in proposals),
+                severity="medium",
+                message="Every proposal should include a human-readable reason.",
+            ),
+            AgentEvalCheck(
+                check_name="proposal_confidence_in_range",
+                passed=all(0.0 <= float(proposal.get("confidence", -1)) <= 1.0 for proposal in proposals),
+                severity="high",
+                message="Every proposal confidence should be between 0.0 and 1.0.",
+            ),
+            AgentEvalCheck(
+                check_name="proposal_urls_unique",
+                passed=len({proposal.get("root_url") for proposal in proposals}) == len(proposals),
+                severity="medium",
+                message="Proposals should not contain duplicate root URLs.",
+            ),
+            AgentEvalCheck(
+                check_name="gap_coverage_present",
+                passed=len(considered_gap_codes) > 0,
+                severity="low",
+                message="Source planner output should disclose the gap codes it considered.",
+            ),
+        ]
+        return checks
+
+    def _evaluate_evidence_critic_payload(self, payload: dict) -> list[AgentEvalCheck]:
+        critiques = payload.get("critiques") or []
+
+        checks = [
+            AgentEvalCheck(
+                check_name="has_critiques",
+                passed=len(critiques) > 0,
+                severity="medium",
+                message="Evidence critic should usually return at least one critique item.",
+            ),
+            AgentEvalCheck(
+                check_name="support_quality_valid",
+                passed=all(critique.get("support_quality") in _ALLOWED_SUPPORT_QUALITIES for critique in critiques),
+                severity="high",
+                message="Support quality should be one of strong, thin, or weak.",
+            ),
+            AgentEvalCheck(
+                check_name="reasons_present",
+                passed=all(bool(critique.get("reason")) for critique in critiques),
+                severity="medium",
+                message="Every critique should include a reason.",
+            ),
+            AgentEvalCheck(
+                check_name="recommendations_present",
+                passed=all(len(critique.get("recommendations") or []) > 0 for critique in critiques),
+                severity="low",
+                message="Every critique should include at least one recommendation.",
+            ),
+            AgentEvalCheck(
+                check_name="confidence_in_range",
+                passed=all(0.0 <= float(critique.get("confidence", -1)) <= 1.0 for critique in critiques),
+                severity="high",
+                message="Every critique confidence should be between 0.0 and 1.0.",
+            ),
+        ]
+        return checks

--- a/packages/services/evidence_critic_agent.py
+++ b/packages/services/evidence_critic_agent.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from packages.contracts.agents import (
+    AgentRunSummary,
+    EvidenceCriticRequest,
+    EvidenceCriticResponse,
+    EvidenceCritiqueItem,
+)
+from packages.observability.tracing import log_event, traced_span
+from packages.services.agent_run_store import AgentRunStore
+from packages.services.product_intelligence import ProductIntelligenceService
+
+STRATEGY_VERSION = "evidence_critic_v1"
+
+
+class EvidenceCriticAgentService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.product_intelligence = ProductIntelligenceService(db)
+        self.agent_run_store = AgentRunStore(db)
+
+    def critique(self, request: EvidenceCriticRequest) -> EvidenceCriticResponse:
+        product_id = uuid.UUID(request.product_id)
+        with traced_span("agent.evidence_critic.critique", product_id=request.product_id):
+            claims_response = self.product_intelligence.get_product_claims(
+                product_id,
+                min_confidence=request.min_confidence,
+                include_stale=True,
+                include_evidence=True,
+            )
+            critiques = [self._critique_claim(claim) for claim in claims_response.items[: request.limit]]
+            log_event(
+                "agent.evidence_critic.completed",
+                product_id=request.product_id,
+                critique_count=len(critiques),
+            )
+            response = EvidenceCriticResponse(
+                product_id=request.product_id,
+                agent=AgentRunSummary(
+                    agent_name="evidence_critic_agent",
+                    strategy_version=STRATEGY_VERSION,
+                    mode="heuristic_scaffold",
+                ),
+                critiques=critiques,
+            )
+            self.agent_run_store.create_agent_run(
+                agent_name="evidence_critic_agent",
+                strategy_version=STRATEGY_VERSION,
+                mode="heuristic_scaffold",
+                product_id=request.product_id,
+                vendor_id=None,
+                request_payload=request.model_dump(),
+                response_payload=response.model_dump(),
+            )
+            self.db.commit()
+            return response
+
+    def _critique_claim(self, claim) -> EvidenceCritiqueItem:
+        support_quality = "strong"
+        reason_parts: list[str] = []
+        recommendations: list[str] = []
+
+        if "stale" in claim.flags:
+            support_quality = "weak"
+            reason_parts.append("Claim support is stale.")
+            recommendations.append("Recrawl the primary source and changelog surfaces.")
+        if claim.source_count <= 1:
+            support_quality = "thin"
+            reason_parts.append("Claim is supported by only one source.")
+            recommendations.append("Find a second confirming source, ideally docs or API reference.")
+        if not claim.evidence:
+            support_quality = "weak"
+            reason_parts.append("No evidence excerpts were returned in the current payload.")
+            recommendations.append("Request the claim with include_evidence enabled for manual review.")
+        if "docs_backed" in claim.flags and claim.source_count > 1 and "stale" not in claim.flags:
+            reason_parts.append("Claim is backed by docs-like evidence and multiple sources.")
+            if support_quality == "strong":
+                recommendations.append("No immediate action needed.")
+
+        if not reason_parts:
+            reason_parts.append("Claim support is adequate but should still be periodically refreshed.")
+            recommendations.append("Monitor for freshness drift.")
+
+        return EvidenceCritiqueItem(
+            claim_id=claim.claim_id,
+            claim_type=claim.claim_type,
+            normalized_key=claim.normalized_key,
+            display_label=claim.display_label,
+            support_quality=support_quality,
+            confidence=claim.confidence,
+            reason=" ".join(reason_parts),
+            recommendations=recommendations,
+        )

--- a/packages/services/source_promotion.py
+++ b/packages/services/source_promotion.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from packages.contracts.source_promotion import (
+    PromoteSourceProposalRequest,
+    PromoteSourceProposalResponse,
+    RejectSourceProposalRequest,
+    RejectSourceProposalResponse,
+)
+from packages.core.models import CrawlJob, Product, Source, Vendor
+from packages.observability.tracing import log_event, traced_span
+from packages.services.agent_run_store import AgentRunStore
+
+_ACTIVE_JOB_STATUSES = {"queued", "leased", "retryable"}
+
+
+class SourcePromotionService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.agent_run_store = AgentRunStore(db)
+
+    def promote(self, request: PromoteSourceProposalRequest) -> PromoteSourceProposalResponse:
+        product_id = uuid.UUID(request.product_id)
+        with traced_span("source_promotion.promote", product_id=request.product_id):
+            product, vendor = self._get_product_vendor(product_id)
+
+            existing_source = self.db.execute(
+                select(Source).where(
+                    Source.product_id == product_id,
+                    Source.root_url == request.proposal.root_url,
+                )
+            ).scalar_one_or_none()
+
+            created_source = False
+            deduped_existing_source = existing_source is not None
+            if existing_source is None:
+                source = Source(
+                    vendor_id=vendor.vendor_id,
+                    product_id=product.product_id,
+                    source_family=request.proposal.source_family,
+                    source_type=request.proposal.source_type,
+                    root_url=request.proposal.root_url,
+                    connector_type=request.proposal.connector_type,
+                    is_active=True,
+                    source_metadata={
+                        "promotion_reason": request.proposal.reason,
+                        "target_gap_codes": request.proposal.target_gap_codes,
+                        "proposal_confidence": request.proposal.confidence,
+                        "promotion_note": request.note,
+                        "trigger": "agent_source_promotion",
+                    },
+                )
+                self.db.add(source)
+                self.db.flush()
+                existing_source = source
+                created_source = True
+
+            crawl_job_id: str | None = None
+            created_crawl_job = False
+            if request.create_crawl_job:
+                existing_job = self.db.execute(
+                    select(CrawlJob).where(
+                        CrawlJob.source_id == existing_source.source_id,
+                        CrawlJob.job_type == "fetch_source",
+                        CrawlJob.status.in_(_ACTIVE_JOB_STATUSES),
+                    )
+                ).scalar_one_or_none()
+                if existing_job is None:
+                    worker_queue = "browser_fetch" if existing_source.connector_type == "browser" else "api_fetch"
+                    job = CrawlJob(
+                        vendor_id=existing_source.vendor_id,
+                        product_id=existing_source.product_id,
+                        source_id=existing_source.source_id,
+                        job_type="fetch_source",
+                        worker_queue=worker_queue,
+                        status="queued",
+                        priority=request.crawl_priority,
+                        max_attempts=3,
+                        payload={
+                            "source_id": str(existing_source.source_id),
+                            "product_id": str(existing_source.product_id) if existing_source.product_id else None,
+                            "vendor_id": str(existing_source.vendor_id) if existing_source.vendor_id else None,
+                            "root_url": existing_source.root_url,
+                            "source_type": existing_source.source_type,
+                            "trigger": "source_promotion",
+                            "promotion_note": request.note,
+                        },
+                    )
+                    self.db.add(job)
+                    self.db.flush()
+                    crawl_job_id = str(job.crawl_job_id)
+                    created_crawl_job = True
+                else:
+                    crawl_job_id = str(existing_job.crawl_job_id)
+
+            response = PromoteSourceProposalResponse(
+                product_id=request.product_id,
+                source_id=str(existing_source.source_id),
+                crawl_job_id=crawl_job_id,
+                created_source=created_source,
+                created_crawl_job=created_crawl_job,
+                deduped_existing_source=deduped_existing_source,
+            )
+            self.agent_run_store.create_source_proposal_decision(
+                decision_type="promote",
+                agent_name="source_planner_agent",
+                product_id=request.product_id,
+                vendor_id=str(vendor.vendor_id),
+                source_id=str(existing_source.source_id),
+                crawl_job_id=crawl_job_id,
+                proposal_payload=request.proposal.model_dump(),
+                decision_payload=response.model_dump(),
+                note=request.note,
+            )
+            self.db.commit()
+            log_event(
+                "source_promotion.promoted",
+                product_id=request.product_id,
+                source_id=str(existing_source.source_id),
+                created_source=created_source,
+                created_crawl_job=created_crawl_job,
+                deduped_existing_source=deduped_existing_source,
+            )
+            return response
+
+    def reject(self, request: RejectSourceProposalRequest) -> RejectSourceProposalResponse:
+        with traced_span("source_promotion.reject", product_id=request.product_id):
+            response = RejectSourceProposalResponse(
+                product_id=request.product_id,
+                rejected=True,
+                reason=request.reason,
+                proposal_root_url=request.proposal.root_url,
+            )
+            self.agent_run_store.create_source_proposal_decision(
+                decision_type="reject",
+                agent_name="source_planner_agent",
+                product_id=request.product_id,
+                vendor_id=None,
+                source_id=None,
+                crawl_job_id=None,
+                proposal_payload=request.proposal.model_dump(),
+                decision_payload=response.model_dump(),
+                note=request.reason,
+            )
+            self.db.commit()
+            log_event(
+                "source_promotion.rejected",
+                product_id=request.product_id,
+                proposal_root_url=request.proposal.root_url,
+                reason=request.reason,
+            )
+            return response
+
+    def _get_product_vendor(self, product_id: uuid.UUID) -> tuple[Product, Vendor]:
+        row = self.db.execute(
+            select(Product, Vendor)
+            .join(Vendor, Product.vendor_id == Vendor.vendor_id)
+            .where(Product.product_id == product_id)
+        ).one_or_none()
+        if row is None:
+            raise ValueError(f"Product not found: {product_id}")
+        return row

--- a/tests/test_agent_eval_routes.py
+++ b/tests/test_agent_eval_routes.py
@@ -1,0 +1,65 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.contracts.agent_evals import AgentEvalCheck, AgentEvalResponse, AgentEvalScorecard
+from packages.core.deps import get_db
+
+
+class DummyAgentEvaluatorService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def evaluate(self, payload):
+        return AgentEvalResponse(
+            agent_name=payload.agent_name,
+            evaluator_version="agent_evaluator_v1",
+            scorecard=AgentEvalScorecard(
+                overall_passed=True,
+                passed_checks=3,
+                failed_checks=0,
+                score=1.0,
+            ),
+            checks=[
+                AgentEvalCheck(
+                    check_name="has_proposals",
+                    passed=True,
+                    severity="medium",
+                    message="ok",
+                )
+            ],
+        )
+
+
+def override_get_db():
+    yield object()
+
+
+def test_admin_agent_eval_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.agent_evals.AgentEvaluatorService", DummyAgentEvaluatorService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/admin/agent-evals/run",
+        json={
+            "agent_name": "source_planner_agent",
+            "payload": {
+                "proposals": [
+                    {
+                        "root_url": "https://docs.example.com",
+                        "source_type": "docs_subdomain",
+                        "reason": "Docs coverage is missing.",
+                        "confidence": 0.9,
+                    }
+                ],
+                "considered_gap_codes": ["missing_docs_surface"],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["agent_name"] == "source_planner_agent"
+    assert body["scorecard"]["overall_passed"] is True
+
+    app.dependency_overrides.clear()

--- a/tests/test_agent_evaluator.py
+++ b/tests/test_agent_evaluator.py
@@ -1,0 +1,73 @@
+from packages.contracts.agent_evals import AgentEvalRequest
+from packages.services.agent_evaluator import AgentEvaluatorService
+
+
+class DummyStore:
+    def __init__(self):
+        self.calls = []
+
+    def create_agent_eval_run(self, **kwargs):
+        self.calls.append(kwargs)
+        return object()
+
+
+class DummySession:
+    def commit(self):
+        return None
+
+
+def test_evaluate_source_planner_payload_scores_expected_checks() -> None:
+    service = AgentEvaluatorService(DummySession())  # type: ignore[arg-type]
+    service.agent_run_store = DummyStore()
+
+    response = service.evaluate(
+        AgentEvalRequest(
+            agent_name="source_planner_agent",
+            payload={
+                "considered_gap_codes": ["missing_docs_surface"],
+                "proposals": [
+                    {
+                        "root_url": "https://docs.example.com",
+                        "source_type": "docs_subdomain",
+                        "reason": "Docs coverage is missing.",
+                        "confidence": 0.9,
+                    }
+                ],
+            },
+        )
+    )
+
+    assert response.agent_name == "source_planner_agent"
+    assert response.scorecard.failed_checks == 0
+    assert response.scorecard.overall_passed is True
+    assert len(service.agent_run_store.calls) == 1
+
+
+def test_evaluate_evidence_critic_payload_flags_missing_recommendations() -> None:
+    service = AgentEvaluatorService(DummySession())  # type: ignore[arg-type]
+    service.agent_run_store = DummyStore()
+
+    response = service.evaluate(
+        AgentEvalRequest(
+            agent_name="evidence_critic_agent",
+            payload={
+                "critiques": [
+                    {
+                        "claim_id": "capability:single_sign_on",
+                        "claim_type": "capability",
+                        "normalized_key": "single_sign_on",
+                        "display_label": "Single Sign-On",
+                        "support_quality": "thin",
+                        "confidence": 0.82,
+                        "reason": "Only one source supports this claim.",
+                        "recommendations": [],
+                    }
+                ]
+            },
+        )
+    )
+
+    assert response.agent_name == "evidence_critic_agent"
+    assert response.scorecard.failed_checks >= 1
+    assert len(service.agent_run_store.calls) == 1
+    assert any(check.check_name == "recommendations_present" and not check.passed for check in response.checks)

--- a/tests/test_agents_routes.py
+++ b/tests/test_agents_routes.py
@@ -1,7 +1,13 @@
 from fastapi.testclient import TestClient
 
 from apps.api.main import app
-from packages.contracts.agents import AgentRunSummary, SourcePlannerResponse, SourceProposal
+from packages.contracts.agents import (
+    AgentRunSummary,
+    EvidenceCriticResponse,
+    EvidenceCritiqueItem,
+    SourcePlannerResponse,
+    SourceProposal,
+)
 from packages.core.deps import get_db
 
 
@@ -30,6 +36,33 @@ class DummySourcePlannerAgentService:
         )
 
 
+class DummyEvidenceCriticAgentService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def critique(self, request):
+        return EvidenceCriticResponse(
+            product_id=request.product_id,
+            agent=AgentRunSummary(
+                agent_name="evidence_critic_agent",
+                strategy_version="evidence_critic_v1",
+                mode="heuristic_scaffold",
+            ),
+            critiques=[
+                EvidenceCritiqueItem(
+                    claim_id="capability:single_sign_on",
+                    claim_type="capability",
+                    normalized_key="single_sign_on",
+                    display_label="Single Sign-On",
+                    support_quality="thin",
+                    confidence=0.82,
+                    reason="Claim is supported by only one source.",
+                    recommendations=["Find a second confirming source, ideally docs or API reference."],
+                )
+            ],
+        )
+
+
 def override_get_db():
     yield object()
 
@@ -49,5 +82,24 @@ def test_source_planner_agent_endpoint_returns_payload(monkeypatch) -> None:
     assert body["agent"]["agent_name"] == "source_planner_agent"
     assert body["proposals"][0]["root_url"] == "https://docs.example.com"
     assert body["considered_gap_codes"] == ["missing_docs_surface"]
+
+    app.dependency_overrides.clear()
+
+
+def test_evidence_critic_agent_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.agents.EvidenceCriticAgentService", DummyEvidenceCriticAgentService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/agents/evidence-critic/critique",
+        json={"product_id": "00000000-0000-0000-0000-000000000001", "min_confidence": 0.6, "limit": 5},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["agent"]["agent_name"] == "evidence_critic_agent"
+    assert body["critiques"][0]["support_quality"] == "thin"
+    assert body["critiques"][0]["normalized_key"] == "single_sign_on"
 
     app.dependency_overrides.clear()

--- a/tests/test_evidence_critic_agent.py
+++ b/tests/test_evidence_critic_agent.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timezone
+
+from packages.contracts.claims import ClaimEvidenceRef, NormalizedClaim
+from packages.services.evidence_critic_agent import EvidenceCriticAgentService
+
+
+class DummyStore:
+    def __init__(self):
+        self.calls = []
+
+    def create_agent_run(self, **kwargs):
+        self.calls.append(kwargs)
+        return object()
+
+
+class DummySession:
+    def commit(self):
+        return None
+
+
+def _claim(*, claim_id: str, flags: list[str], source_count: int, include_evidence: bool) -> NormalizedClaim:
+    evidence = []
+    if include_evidence:
+        evidence = [
+            ClaimEvidenceRef(
+                evidence_id="e1",
+                page_id="p1",
+                source_id="s1",
+                canonical_url="https://docs.example.com",
+                page_type="docs",
+                snippet="Supports SSO.",
+                confidence=0.82,
+                created_at=datetime.now(timezone.utc),
+            )
+        ]
+    return NormalizedClaim(
+        claim_id=claim_id,
+        claim_type="capability",
+        normalized_key="single_sign_on",
+        display_label="Single Sign-On",
+        confidence=0.82,
+        support_count=1,
+        source_count=source_count,
+        page_count=1,
+        freshness_score=1.0,
+        latest_evidence_at=datetime.now(timezone.utc),
+        flags=flags,
+        evidence=evidence,
+    )
+
+
+def test_critique_claim_marks_thin_or_stale_support() -> None:
+    service = EvidenceCriticAgentService(DummySession())  # type: ignore[arg-type]
+    service.agent_run_store = DummyStore()
+
+    thin_claim = _claim(claim_id="c1", flags=[], source_count=1, include_evidence=True)
+    stale_claim = _claim(claim_id="c2", flags=["stale"], source_count=2, include_evidence=False)
+
+    thin_result = service._critique_claim(thin_claim)
+    stale_result = service._critique_claim(stale_claim)
+
+    assert thin_result.support_quality == "thin"
+    assert "one source" in thin_result.reason.lower()
+    assert stale_result.support_quality == "weak"
+    assert any("include_evidence" in recommendation for recommendation in stale_result.recommendations)

--- a/tests/test_source_promotion.py
+++ b/tests/test_source_promotion.py
@@ -1,0 +1,138 @@
+from uuid import uuid4
+
+from packages.contracts.agents import SourceProposal
+from packages.contracts.source_promotion import (
+    PromoteSourceProposalRequest,
+    RejectSourceProposalRequest,
+)
+from packages.services.source_promotion import SourcePromotionService
+
+
+class DummyStore:
+    def __init__(self):
+        self.calls = []
+
+    def create_source_proposal_decision(self, **kwargs):
+        self.calls.append(kwargs)
+        return object()
+
+
+class DummyProduct:
+    def __init__(self) -> None:
+        self.product_id = uuid4()
+        self.vendor_id = uuid4()
+        self.canonical_name = "Example Product"
+
+
+class DummyVendor:
+    def __init__(self, vendor_id) -> None:
+        self.vendor_id = vendor_id
+        self.canonical_name = "Example Vendor"
+
+
+class DummySource:
+    def __init__(self) -> None:
+        self.source_id = uuid4()
+        self.vendor_id = uuid4()
+        self.product_id = uuid4()
+        self.connector_type = "browser"
+        self.root_url = "https://docs.example.com"
+        self.source_type = "docs_subdomain"
+
+
+class DummyScalarResult:
+    def __init__(self, value) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class DummyRowResult:
+    def __init__(self, value) -> None:
+        self._value = value
+
+    def one_or_none(self):
+        return self._value
+
+
+class DummySession:
+    def __init__(self, product=None, vendor=None, existing_source=None, existing_job=None) -> None:
+        self.product = product
+        self.vendor = vendor
+        self.existing_source = existing_source
+        self.existing_job = existing_job
+        self.added = []
+        self._execute_count = 0
+
+    def execute(self, stmt):
+        self._execute_count += 1
+        if self._execute_count == 1:
+            return DummyRowResult((self.product, self.vendor))
+        if self._execute_count == 2:
+            return DummyScalarResult(self.existing_source)
+        return DummyScalarResult(self.existing_job)
+
+    def add(self, obj):
+        self.added.append(obj)
+        if getattr(obj, "source_id", None) is None and hasattr(obj, "root_url"):
+            obj.source_id = uuid4()
+            obj.vendor_id = self.vendor.vendor_id
+            obj.product_id = self.product.product_id
+        if getattr(obj, "crawl_job_id", None) is None and hasattr(obj, "job_type"):
+            obj.crawl_job_id = uuid4()
+
+    def flush(self):
+        return None
+
+    def commit(self):
+        return None
+
+
+def _proposal() -> SourceProposal:
+    return SourceProposal(
+        root_url="https://docs.example.com",
+        source_type="docs_subdomain",
+        reason="Docs coverage is missing.",
+        target_gap_codes=["missing_docs_surface"],
+        confidence=0.9,
+    )
+
+
+def test_promote_creates_source_and_persists_decision() -> None:
+    product = DummyProduct()
+    vendor = DummyVendor(product.vendor_id)
+    session = DummySession(product=product, vendor=vendor, existing_source=None, existing_job=None)
+    service = SourcePromotionService(session)  # type: ignore[arg-type]
+    service.agent_run_store = DummyStore()
+
+    result = service.promote(
+        PromoteSourceProposalRequest(
+            product_id=str(product.product_id),
+            proposal=_proposal(),
+            create_crawl_job=True,
+            crawl_priority=91,
+        )
+    )
+
+    assert result.created_source is True
+    assert result.created_crawl_job is True
+    assert len(service.agent_run_store.calls) == 1
+    assert service.agent_run_store.calls[0]["decision_type"] == "promote"
+
+
+def test_reject_persists_decision() -> None:
+    service = SourcePromotionService(DummySession())  # type: ignore[arg-type]
+    service.agent_run_store = DummyStore()
+
+    result = service.reject(
+        RejectSourceProposalRequest(
+            product_id="00000000-0000-0000-0000-000000000001",
+            proposal=_proposal(),
+            reason="Low-confidence source guess.",
+        )
+    )
+
+    assert result.rejected is True
+    assert len(service.agent_run_store.calls) == 1
+    assert service.agent_run_store.calls[0]["decision_type"] == "reject"

--- a/tests/test_source_promotion_routes.py
+++ b/tests/test_source_promotion_routes.py
@@ -1,0 +1,97 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.contracts.source_promotion import (
+    PromoteSourceProposalResponse,
+    RejectSourceProposalResponse,
+)
+from packages.core.deps import get_db
+
+
+class DummySourcePromotionService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def promote(self, payload):
+        return PromoteSourceProposalResponse(
+            product_id=payload.product_id,
+            source_id="11111111-1111-1111-1111-111111111111",
+            crawl_job_id="22222222-2222-2222-2222-222222222222",
+            created_source=True,
+            created_crawl_job=True,
+            deduped_existing_source=False,
+        )
+
+    def reject(self, payload):
+        return RejectSourceProposalResponse(
+            product_id=payload.product_id,
+            rejected=True,
+            reason=payload.reason,
+            proposal_root_url=payload.proposal.root_url,
+        )
+
+
+def override_get_db():
+    yield object()
+
+
+def test_promote_source_proposal_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.source_promotion.SourcePromotionService", DummySourcePromotionService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/admin/source-proposals/promote",
+        json={
+            "product_id": "00000000-0000-0000-0000-000000000001",
+            "proposal": {
+                "root_url": "https://docs.example.com",
+                "source_type": "docs_subdomain",
+                "source_family": "vendor_owned",
+                "connector_type": "browser",
+                "reason": "Docs coverage is missing.",
+                "target_gap_codes": ["missing_docs_surface"],
+                "confidence": 0.9,
+            },
+            "create_crawl_job": True,
+            "crawl_priority": 90,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["created_source"] is True
+    assert body["created_crawl_job"] is True
+    assert body["deduped_existing_source"] is False
+
+    app.dependency_overrides.clear()
+
+
+def test_reject_source_proposal_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.source_promotion.SourcePromotionService", DummySourcePromotionService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/admin/source-proposals/reject",
+        json={
+            "product_id": "00000000-0000-0000-0000-000000000001",
+            "proposal": {
+                "root_url": "https://docs.example.com",
+                "source_type": "docs_subdomain",
+                "source_family": "vendor_owned",
+                "connector_type": "browser",
+                "reason": "Docs coverage is missing.",
+                "target_gap_codes": ["missing_docs_surface"],
+                "confidence": 0.9,
+            },
+            "reason": "Low-confidence guess.",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["rejected"] is True
+    assert body["proposal_root_url"] == "https://docs.example.com"
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## What this ships

Consolidates the first operational agent loop on top of the new persistence foundation.

### Included
- evidence critic endpoint and persistence-aware service
- agent evaluator endpoint and persistence-aware service
- source proposal promotion and rejection endpoints with decision persistence
- app wiring for admin eval and source promotion surfaces
- route and service tests for the loop components

## Scope
- `POST /v1/agents/evidence-critic/critique`
- `POST /v1/admin/agent-evals/run`
- `POST /v1/admin/source-proposals/promote`
- `POST /v1/admin/source-proposals/reject`
- persistence-backed writes for critique, eval, and proposal decisions

## Why now
This turns the current agent layer from a set of separate drafts into one coherent operational loop: propose, critique, evaluate, and act with durable records.
