### PR TITLE
PR-013: add admin query surfaces for agent operations

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from apps.api.routes.admin import router as admin_router
+from apps.api.routes.admin_agent_ops import router as admin_agent_ops_router
 from apps.api.routes.agent_evals import router as agent_evals_router
 from apps.api.routes.agents import router as agents_router
 from apps.api.routes.compare import router as compare_router
@@ -19,6 +20,7 @@ app.add_middleware(RequestTracingMiddleware)
 
 app.include_router(vendors_router)
 app.include_router(admin_router)
+app.include_router(admin_agent_ops_router)
 app.include_router(agent_evals_router)
 app.include_router(source_promotion_router)
 app.include_router(products_router)

--- a/apps/api/routes/admin_agent_ops.py
+++ b/apps/api/routes/admin_agent_ops.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from packages.contracts.admin import (
+    AgentEvalRunListResponse,
+    AgentRunListResponse,
+    SourceProposalDecisionListResponse,
+)
+from packages.contracts.api_common import ApiEnvelope
+from packages.core.deps import get_db
+from packages.services.admin_queries import AdminQueryService
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+@router.get("/agent-runs", response_model=ApiEnvelope)
+def list_agent_runs(
+    agent_name: str | None = Query(default=None),
+    product_id: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    trace_id: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: AgentRunListResponse = AdminQueryService(db).list_agent_runs(
+        agent_name=agent_name,
+        product_id=product_id,
+        status=status,
+        trace_id=trace_id,
+        limit=limit,
+    )
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.get("/agent-evals", response_model=ApiEnvelope)
+def list_agent_eval_runs(
+    agent_name: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    trace_id: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: AgentEvalRunListResponse = AdminQueryService(db).list_agent_eval_runs(
+        agent_name=agent_name,
+        status=status,
+        trace_id=trace_id,
+        limit=limit,
+    )
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.get("/source-proposal-decisions", response_model=ApiEnvelope)
+def list_source_proposal_decisions(
+    decision_type: str | None = Query(default=None),
+    product_id: str | None = Query(default=None),
+    trace_id: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: SourceProposalDecisionListResponse = AdminQueryService(db).list_source_proposal_decisions(
+        decision_type=decision_type,
+        product_id=product_id,
+        trace_id=trace_id,
+        limit=limit,
+    )
+    return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/admin.py
+++ b/packages/contracts/admin.py
@@ -88,3 +88,56 @@ class SourceSummary(BaseModel):
 class VendorSourcesResponse(BaseModel):
     vendor_id: str
     items: list[SourceSummary]
+
+
+class AgentRunSummary(BaseModel):
+    agent_run_id: str
+    agent_name: str
+    strategy_version: str | None
+    mode: str | None
+    status: str
+    trace_id: str | None
+    request_id: str | None
+    product_id: str | None
+    vendor_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentRunListResponse(BaseModel):
+    items: list[AgentRunSummary]
+
+
+class AgentEvalRunSummary(BaseModel):
+    agent_eval_run_id: str
+    agent_name: str
+    evaluator_version: str
+    status: str
+    trace_id: str | None
+    score: float | None
+    overall_passed: bool | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentEvalRunListResponse(BaseModel):
+    items: list[AgentEvalRunSummary]
+
+
+class SourceProposalDecisionSummary(BaseModel):
+    source_proposal_decision_id: str
+    decision_type: str
+    agent_name: str | None
+    trace_id: str | None
+    product_id: str | None
+    vendor_id: str | None
+    source_id: str | None
+    crawl_job_id: str | None
+    proposal_root_url: str | None
+    note: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SourceProposalDecisionListResponse(BaseModel):
+    items: list[SourceProposalDecisionSummary]

--- a/packages/services/admin_queries.py
+++ b/packages/services/admin_queries.py
@@ -6,16 +6,22 @@ from sqlalchemy import Select, select
 from sqlalchemy.orm import Session
 
 from packages.contracts.admin import (
+    AgentEvalRunListResponse,
+    AgentEvalRunSummary,
+    AgentRunListResponse,
+    AgentRunSummary,
     CrawlJobListResponse,
     CrawlJobSummary,
     EvidenceListResponse,
     EvidenceSummary,
     PageListResponse,
     PageSummary,
+    SourceProposalDecisionListResponse,
+    SourceProposalDecisionSummary,
     SourceSummary,
     VendorSourcesResponse,
 )
-from packages.core.models import CrawlJob, Evidence, Page, Source
+from packages.core.models import AgentEvalRun, AgentRun, CrawlJob, Evidence, Page, Source, SourceProposalDecision
 
 
 class AdminQueryService:
@@ -158,3 +164,88 @@ class AdminQueryService:
             for source in rows
         ]
         return VendorSourcesResponse(vendor_id=str(vendor_id), items=items)
+
+    def list_agent_runs(self, *, agent_name: str | None, product_id: str | None, status: str | None, trace_id: str | None, limit: int) -> AgentRunListResponse:
+        stmt: Select = select(AgentRun).order_by(AgentRun.created_at.desc()).limit(limit)
+        if agent_name:
+            stmt = stmt.where(AgentRun.agent_name == agent_name)
+        if product_id:
+            stmt = stmt.where(AgentRun.product_id == uuid.UUID(product_id))
+        if status:
+            stmt = stmt.where(AgentRun.status == status)
+        if trace_id:
+            stmt = stmt.where(AgentRun.trace_id == trace_id)
+
+        rows = self.db.execute(stmt).scalars()
+        items = [
+            AgentRunSummary(
+                agent_run_id=str(run.agent_run_id),
+                agent_name=run.agent_name,
+                strategy_version=run.strategy_version,
+                mode=run.mode,
+                status=run.status,
+                trace_id=run.trace_id,
+                request_id=run.request_id,
+                product_id=str(run.product_id) if run.product_id else None,
+                vendor_id=str(run.vendor_id) if run.vendor_id else None,
+                created_at=run.created_at,
+                updated_at=run.updated_at,
+            )
+            for run in rows
+        ]
+        return AgentRunListResponse(items=items)
+
+    def list_agent_eval_runs(self, *, agent_name: str | None, status: str | None, trace_id: str | None, limit: int) -> AgentEvalRunListResponse:
+        stmt: Select = select(AgentEvalRun).order_by(AgentEvalRun.created_at.desc()).limit(limit)
+        if agent_name:
+            stmt = stmt.where(AgentEvalRun.agent_name == agent_name)
+        if status:
+            stmt = stmt.where(AgentEvalRun.status == status)
+        if trace_id:
+            stmt = stmt.where(AgentEvalRun.trace_id == trace_id)
+
+        rows = self.db.execute(stmt).scalars()
+        items = [
+            AgentEvalRunSummary(
+                agent_eval_run_id=str(run.agent_eval_run_id),
+                agent_name=run.agent_name,
+                evaluator_version=run.evaluator_version,
+                status=run.status,
+                trace_id=run.trace_id,
+                score=run.score,
+                overall_passed=run.overall_passed,
+                created_at=run.created_at,
+                updated_at=run.updated_at,
+            )
+            for run in rows
+        ]
+        return AgentEvalRunListResponse(items=items)
+
+    def list_source_proposal_decisions(self, *, decision_type: str | None, product_id: str | None, trace_id: str | None, limit: int) -> SourceProposalDecisionListResponse:
+        stmt: Select = select(SourceProposalDecision).order_by(SourceProposalDecision.created_at.desc()).limit(limit)
+        if decision_type:
+            stmt = stmt.where(SourceProposalDecision.decision_type == decision_type)
+        if product_id:
+            stmt = stmt.where(SourceProposalDecision.product_id == uuid.UUID(product_id))
+        if trace_id:
+            stmt = stmt.where(SourceProposalDecision.trace_id == trace_id)
+
+        rows = self.db.execute(stmt).scalars()
+        items = [
+            SourceProposalDecisionSummary(
+                source_proposal_decision_id=str(decision.source_proposal_decision_id),
+                decision_type=decision.decision_type,
+                agent_name=decision.agent_name,
+                trace_id=decision.trace_id,
+                product_id=str(decision.product_id) if decision.product_id else None,
+                vendor_id=str(decision.vendor_id) if decision.vendor_id else None,
+                source_id=str(decision.source_id) if decision.source_id else None,
+                crawl_job_id=str(decision.crawl_job_id) if decision.crawl_job_id else None,
+                proposal_root_url=decision.proposal_payload.get("root_url"),
+                note=decision.note,
+                created_at=decision.created_at,
+                updated_at=decision.updated_at,
+            )
+            for decision in rows
+        ]
+        return SourceProposalDecisionListResponse(items=items)

--- a/tests/test_admin_agent_ops_routes.py
+++ b/tests/test_admin_agent_ops_routes.py
@@ -1,0 +1,127 @@
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.contracts.admin import (
+    AgentEvalRunListResponse,
+    AgentEvalRunSummary,
+    AgentRunListResponse,
+    AgentRunSummary,
+    SourceProposalDecisionListResponse,
+    SourceProposalDecisionSummary,
+)
+from packages.core.deps import get_db
+
+
+class DummyAdminQueryService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def list_agent_runs(self, **kwargs):
+        now = datetime.now(timezone.utc)
+        return AgentRunListResponse(
+            items=[
+                AgentRunSummary(
+                    agent_run_id="11111111-1111-1111-1111-111111111111",
+                    agent_name="source_planner_agent",
+                    strategy_version="source_planner_v1",
+                    mode="heuristic_scaffold",
+                    status="completed",
+                    trace_id="trace-1",
+                    request_id="request-1",
+                    product_id="00000000-0000-0000-0000-000000000001",
+                    vendor_id=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+            ]
+        )
+
+    def list_agent_eval_runs(self, **kwargs):
+        now = datetime.now(timezone.utc)
+        return AgentEvalRunListResponse(
+            items=[
+                AgentEvalRunSummary(
+                    agent_eval_run_id="22222222-2222-2222-2222-222222222222",
+                    agent_name="source_planner_agent",
+                    evaluator_version="agent_evaluator_v1",
+                    status="completed",
+                    trace_id="trace-1",
+                    score=1.0,
+                    overall_passed=True,
+                    created_at=now,
+                    updated_at=now,
+                )
+            ]
+        )
+
+    def list_source_proposal_decisions(self, **kwargs):
+        now = datetime.now(timezone.utc)
+        return SourceProposalDecisionListResponse(
+            items=[
+                SourceProposalDecisionSummary(
+                    source_proposal_decision_id="33333333-3333-3333-3333-333333333333",
+                    decision_type="promote",
+                    agent_name="source_planner_agent",
+                    trace_id="trace-1",
+                    product_id="00000000-0000-0000-0000-000000000001",
+                    vendor_id=None,
+                    source_id="44444444-4444-4444-4444-444444444444",
+                    crawl_job_id="55555555-5555-5555-5555-555555555555",
+                    proposal_root_url="https://docs.example.com",
+                    note=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+            ]
+        )
+
+
+def override_get_db():
+    yield object()
+
+
+def test_admin_agent_runs_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_agent_ops.AdminQueryService", DummyAdminQueryService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.get("/v1/admin/agent-runs?agent_name=source_planner_agent&limit=10")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["items"][0]["agent_name"] == "source_planner_agent"
+    assert body["items"][0]["trace_id"] == "trace-1"
+
+    app.dependency_overrides.clear()
+
+
+def test_admin_agent_evals_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_agent_ops.AdminQueryService", DummyAdminQueryService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.get("/v1/admin/agent-evals?agent_name=source_planner_agent&limit=10")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["items"][0]["evaluator_version"] == "agent_evaluator_v1"
+    assert body["items"][0]["overall_passed"] is True
+
+    app.dependency_overrides.clear()
+
+
+def test_admin_source_proposal_decisions_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_agent_ops.AdminQueryService", DummyAdminQueryService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.get("/v1/admin/source-proposal-decisions?decision_type=promote&limit=10")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["items"][0]["decision_type"] == "promote"
+    assert body["items"][0]["proposal_root_url"] == "https://docs.example.com"
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## What this ships

Adds admin read/query surfaces for the new persisted agent operations.

### Included
- `GET /v1/admin/agent-runs`
- `GET /v1/admin/agent-evals`
- `GET /v1/admin/source-proposal-decisions`
- shared admin contract extensions for agent run, eval, and decision summaries
- admin query service support for persisted agent tables
- dedicated route coverage for the new admin read module

## Why now
Now that the first operational loop persists agent runs, evaluator runs, and proposal decisions, operators need a first-class way to inspect that state without digging through logs.
