### PR TITLE
PR-014: add claim-first verification to evaluator

### DIFF
--- a/packages/contracts/agent_evals.py
+++ b/packages/contracts/agent_evals.py
@@ -20,8 +20,24 @@ class AgentEvalScorecard(BaseModel):
     score: float = Field(ge=0.0, le=1.0)
 
 
+class ClaimVerificationItem(BaseModel):
+    claim_id: str
+    normalized_key: str
+    bucket: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class ClaimVerificationSummary(BaseModel):
+    backed_claim_count: int
+    thin_claim_count: int
+    unsupported_claim_count: int
+    stale_supported_claim_count: int
+    items: list[ClaimVerificationItem] = Field(default_factory=list)
+
+
 class AgentEvalResponse(BaseModel):
     agent_name: str
     evaluator_version: str
     scorecard: AgentEvalScorecard
     checks: list[AgentEvalCheck] = Field(default_factory=list)
+    claim_verification: ClaimVerificationSummary | None = None

--- a/packages/services/agent_evaluator.py
+++ b/packages/services/agent_evaluator.py
@@ -5,9 +5,11 @@ from packages.contracts.agent_evals import (
     AgentEvalRequest,
     AgentEvalResponse,
     AgentEvalScorecard,
+    ClaimVerificationSummary,
 )
 from packages.observability.tracing import log_event, traced_span
 from packages.services.agent_run_store import AgentRunStore
+from packages.services.claim_verifier import ClaimVerifierService
 
 EVALUATOR_VERSION = "agent_evaluator_v1"
 _ALLOWED_SUPPORT_QUALITIES = {"strong", "thin", "weak"}
@@ -17,13 +19,16 @@ class AgentEvaluatorService:
     def __init__(self, db=None) -> None:
         self.db = db
         self.agent_run_store = AgentRunStore(db) if db is not None else None
+        self.claim_verifier = ClaimVerifierService()
 
     def evaluate(self, request: AgentEvalRequest) -> AgentEvalResponse:
         with traced_span("agent_evaluator.evaluate", agent_name=request.agent_name):
+            claim_verification: ClaimVerificationSummary | None = None
             if request.agent_name == "source_planner_agent":
                 checks = self._evaluate_source_planner_payload(request.payload)
             elif request.agent_name == "evidence_critic_agent":
                 checks = self._evaluate_evidence_critic_payload(request.payload)
+                claim_verification = self.claim_verifier.classify_evidence_critic_payload(request.payload)
             else:
                 checks = [
                     AgentEvalCheck(
@@ -44,6 +49,8 @@ class AgentEvaluatorService:
                 passed_checks=passed_checks,
                 failed_checks=failed_checks,
                 score=score,
+                backed_claim_count=claim_verification.backed_claim_count if claim_verification else None,
+                unsupported_claim_count=claim_verification.unsupported_claim_count if claim_verification else None,
             )
             response = AgentEvalResponse(
                 agent_name=request.agent_name,
@@ -55,6 +62,7 @@ class AgentEvaluatorService:
                     score=score,
                 ),
                 checks=checks,
+                claim_verification=claim_verification,
             )
             if self.agent_run_store is not None:
                 self.agent_run_store.create_agent_eval_run(

--- a/packages/services/claim_verifier.py
+++ b/packages/services/claim_verifier.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from packages.contracts.agent_evals import ClaimVerificationItem, ClaimVerificationSummary
+
+_SUPPORTED_BUCKETS = {"backed", "thin", "unsupported", "stale_supported"}
+
+
+class ClaimVerifierService:
+    def classify_evidence_critic_payload(self, payload: dict) -> ClaimVerificationSummary:
+        critiques = payload.get("critiques") or []
+        items: list[ClaimVerificationItem] = []
+
+        for critique in critiques:
+            support_quality = critique.get("support_quality")
+            confidence = float(critique.get("confidence", 0.0))
+            reason = critique.get("reason") or ""
+
+            if support_quality == "strong":
+                bucket = "backed"
+            elif support_quality == "thin":
+                bucket = "thin"
+            elif support_quality == "weak":
+                if "stale" in reason.lower():
+                    bucket = "stale_supported"
+                else:
+                    bucket = "unsupported"
+            else:
+                bucket = "unsupported"
+
+            if bucket not in _SUPPORTED_BUCKETS:
+                bucket = "unsupported"
+
+            items.append(
+                ClaimVerificationItem(
+                    claim_id=str(critique.get("claim_id")),
+                    normalized_key=str(critique.get("normalized_key")),
+                    bucket=bucket,
+                    confidence=confidence,
+                )
+            )
+
+        return ClaimVerificationSummary(
+            backed_claim_count=len([item for item in items if item.bucket == "backed"]),
+            thin_claim_count=len([item for item in items if item.bucket == "thin"]),
+            unsupported_claim_count=len([item for item in items if item.bucket == "unsupported"]),
+            stale_supported_claim_count=len([item for item in items if item.bucket == "stale_supported"]),
+            items=items,
+        )

--- a/tests/test_agent_evaluator.py
+++ b/tests/test_agent_evaluator.py
@@ -40,10 +40,11 @@ def test_evaluate_source_planner_payload_scores_expected_checks() -> None:
     assert response.agent_name == "source_planner_agent"
     assert response.scorecard.failed_checks == 0
     assert response.scorecard.overall_passed is True
+    assert response.claim_verification is None
     assert len(service.agent_run_store.calls) == 1
 
 
-def test_evaluate_evidence_critic_payload_flags_missing_recommendations() -> None:
+def test_evaluate_evidence_critic_payload_flags_missing_recommendations_and_returns_claim_verification() -> None:
     service = AgentEvaluatorService(DummySession())  # type: ignore[arg-type]
     service.agent_run_store = DummyStore()
 
@@ -61,7 +62,17 @@ def test_evaluate_evidence_critic_payload_flags_missing_recommendations() -> Non
                         "confidence": 0.82,
                         "reason": "Only one source supports this claim.",
                         "recommendations": [],
-                    }
+                    },
+                    {
+                        "claim_id": "capability:api_access",
+                        "claim_type": "capability",
+                        "normalized_key": "api_access",
+                        "display_label": "API Access",
+                        "support_quality": "weak",
+                        "confidence": 0.41,
+                        "reason": "Claim support is stale.",
+                        "recommendations": ["Recrawl the primary source and changelog surfaces."],
+                    },
                 ]
             },
         )
@@ -70,4 +81,7 @@ def test_evaluate_evidence_critic_payload_flags_missing_recommendations() -> Non
     assert response.agent_name == "evidence_critic_agent"
     assert response.scorecard.failed_checks >= 1
     assert len(service.agent_run_store.calls) == 1
+    assert response.claim_verification is not None
+    assert response.claim_verification.thin_claim_count == 1
+    assert response.claim_verification.stale_supported_claim_count == 1
     assert any(check.check_name == "recommendations_present" and not check.passed for check in response.checks)

--- a/tests/test_claim_verifier.py
+++ b/tests/test_claim_verifier.py
@@ -1,0 +1,46 @@
+from packages.services.claim_verifier import ClaimVerifierService
+
+
+def test_classify_evidence_critic_payload_counts_claim_buckets() -> None:
+    service = ClaimVerifierService()
+
+    summary = service.classify_evidence_critic_payload(
+        {
+            "critiques": [
+                {
+                    "claim_id": "capability:sso",
+                    "normalized_key": "single_sign_on",
+                    "support_quality": "strong",
+                    "confidence": 0.91,
+                    "reason": "Docs-backed and supported by multiple sources.",
+                },
+                {
+                    "claim_id": "capability:slack",
+                    "normalized_key": "slack",
+                    "support_quality": "thin",
+                    "confidence": 0.74,
+                    "reason": "Only one source supports this claim.",
+                },
+                {
+                    "claim_id": "capability:api",
+                    "normalized_key": "api_access",
+                    "support_quality": "weak",
+                    "confidence": 0.41,
+                    "reason": "Claim support is stale.",
+                },
+                {
+                    "claim_id": "capability:bad",
+                    "normalized_key": "unknown",
+                    "support_quality": "weak",
+                    "confidence": 0.2,
+                    "reason": "No evidence excerpts were returned.",
+                },
+            ]
+        }
+    )
+
+    assert summary.backed_claim_count == 1
+    assert summary.thin_claim_count == 1
+    assert summary.stale_supported_claim_count == 1
+    assert summary.unsupported_claim_count == 1
+    assert len(summary.items) == 4


### PR DESCRIPTION
## What this ships

Adds the first claim-first verification slice to the agent layer.

### Included
- `packages/services/claim_verifier.py`
- evaluator contract extensions for claim verification summaries
- evaluator integration for evidence critic payload classification
- tests for claim bucket classification and evaluator claim-verification output

## Scope
- classify evidence critic output into:
  - backed
  - thin
  - unsupported
  - stale_supported
- return claim verification counts in `AgentEvalResponse`
- persist enriched evaluator output through the existing eval run store path

## Why now
This is the first concrete step from format-only evaluation toward truthfulness and grounding evaluation using claims as the unit of verification.
