### PR TITLE
PR-015: add claim verification summaries to evidence critic

### DIFF
--- a/packages/contracts/agents.py
+++ b/packages/contracts/agents.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field
 
+from packages.contracts.agent_evals import ClaimVerificationSummary
+
 
 class SourcePlannerRequest(BaseModel):
     product_id: str
@@ -51,3 +53,4 @@ class EvidenceCriticResponse(BaseModel):
     product_id: str
     agent: AgentRunSummary
     critiques: list[EvidenceCritiqueItem] = Field(default_factory=list)
+    claim_verification: ClaimVerificationSummary | None = None

--- a/packages/services/evidence_critic_agent.py
+++ b/packages/services/evidence_critic_agent.py
@@ -12,6 +12,7 @@ from packages.contracts.agents import (
 )
 from packages.observability.tracing import log_event, traced_span
 from packages.services.agent_run_store import AgentRunStore
+from packages.services.claim_verifier import ClaimVerifierService
 from packages.services.product_intelligence import ProductIntelligenceService
 
 STRATEGY_VERSION = "evidence_critic_v1"
@@ -22,6 +23,7 @@ class EvidenceCriticAgentService:
         self.db = db
         self.product_intelligence = ProductIntelligenceService(db)
         self.agent_run_store = AgentRunStore(db)
+        self.claim_verifier = ClaimVerifierService()
 
     def critique(self, request: EvidenceCriticRequest) -> EvidenceCriticResponse:
         product_id = uuid.UUID(request.product_id)
@@ -33,10 +35,14 @@ class EvidenceCriticAgentService:
                 include_evidence=True,
             )
             critiques = [self._critique_claim(claim) for claim in claims_response.items[: request.limit]]
+            temp_payload = {"critiques": [critique.model_dump() for critique in critiques]}
+            claim_verification = self.claim_verifier.classify_evidence_critic_payload(temp_payload)
             log_event(
                 "agent.evidence_critic.completed",
                 product_id=request.product_id,
                 critique_count=len(critiques),
+                backed_claim_count=claim_verification.backed_claim_count,
+                unsupported_claim_count=claim_verification.unsupported_claim_count,
             )
             response = EvidenceCriticResponse(
                 product_id=request.product_id,
@@ -46,6 +52,7 @@ class EvidenceCriticAgentService:
                     mode="heuristic_scaffold",
                 ),
                 critiques=critiques,
+                claim_verification=claim_verification,
             )
             self.agent_run_store.create_agent_run(
                 agent_name="evidence_critic_agent",

--- a/tests/test_evidence_critic_agent.py
+++ b/tests/test_evidence_critic_agent.py
@@ -18,6 +18,19 @@ class DummySession:
         return None
 
 
+class DummyClaimsResponse:
+    def __init__(self, items):
+        self.items = items
+
+
+class DummyProductIntelligence:
+    def __init__(self, items):
+        self.items = items
+
+    def get_product_claims(self, product_id, min_confidence, include_stale, include_evidence):
+        return DummyClaimsResponse(self.items)
+
+
 def _claim(*, claim_id: str, flags: list[str], source_count: int, include_evidence: bool) -> NormalizedClaim:
     evidence = []
     if include_evidence:
@@ -36,8 +49,8 @@ def _claim(*, claim_id: str, flags: list[str], source_count: int, include_eviden
     return NormalizedClaim(
         claim_id=claim_id,
         claim_type="capability",
-        normalized_key="single_sign_on",
-        display_label="Single Sign-On",
+        normalized_key="single_sign_on" if claim_id == "c1" else "api_access",
+        display_label="Single Sign-On" if claim_id == "c1" else "API Access",
         confidence=0.82,
         support_count=1,
         source_count=source_count,
@@ -63,3 +76,20 @@ def test_critique_claim_marks_thin_or_stale_support() -> None:
     assert "one source" in thin_result.reason.lower()
     assert stale_result.support_quality == "weak"
     assert any("include_evidence" in recommendation for recommendation in stale_result.recommendations)
+
+
+def test_critique_returns_claim_verification_summary() -> None:
+    items = [
+        _claim(claim_id="c1", flags=[], source_count=1, include_evidence=True),
+        _claim(claim_id="c2", flags=["stale"], source_count=2, include_evidence=False),
+    ]
+    service = EvidenceCriticAgentService(DummySession())  # type: ignore[arg-type]
+    service.product_intelligence = DummyProductIntelligence(items)
+    service.agent_run_store = DummyStore()
+
+    response = service.critique(type("Req", (), {"product_id": "00000000-0000-0000-0000-000000000001", "min_confidence": 0.6, "limit": 5, "model_dump": lambda self: {"product_id": "00000000-0000-0000-0000-000000000001", "min_confidence": 0.6, "limit": 5}})())
+
+    assert response.claim_verification is not None
+    assert response.claim_verification.thin_claim_count == 1
+    assert response.claim_verification.stale_supported_claim_count == 1
+    assert len(service.agent_run_store.calls) == 1


### PR DESCRIPTION
## What this ships

Extends Sprint 3 claim-first verification directly into the evidence critic output surface.

### Included
- `EvidenceCriticResponse` now includes `claim_verification`
- evidence critic service classifies critique output into claim buckets using the shared verifier
- test coverage for returned claim-verification counts on evidence critic responses

## Scope
- surface claim verification earlier, not only inside evaluator output
- classify critique output into:
  - backed
  - thin
  - unsupported
  - stale_supported
- persist enriched evidence critic output through the existing agent run store path

## Why now
This makes claim-first verification visible directly in a user-facing agent response, which is the next logical Sprint 3 step after adding claim verification to evaluator output.
