### PR TITLE
PR-018: add source registry foundation and admin surface

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 from apps.api.routes.admin import router as admin_router
 from apps.api.routes.admin_agent_ops import router as admin_agent_ops_router
+from apps.api.routes.admin_source_registry import router as admin_source_registry_router
 from apps.api.routes.agent_evals import router as agent_evals_router
 from apps.api.routes.agents import router as agents_router
 from apps.api.routes.compare import router as compare_router
@@ -21,6 +22,7 @@ app.add_middleware(RequestTracingMiddleware)
 app.include_router(vendors_router)
 app.include_router(admin_router)
 app.include_router(admin_agent_ops_router)
+app.include_router(admin_source_registry_router)
 app.include_router(agent_evals_router)
 app.include_router(source_promotion_router)
 app.include_router(products_router)

--- a/apps/api/routes/admin_source_registry.py
+++ b/apps/api/routes/admin_source_registry.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from packages.contracts.api_common import ApiEnvelope
+from packages.contracts.source_registry import SourceRegistryListResponse
+from packages.core.deps import get_db
+from packages.services.source_registry import SourceRegistryService
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+@router.get("/source-registry", response_model=ApiEnvelope)
+def list_source_registry(
+    product_id: str | None = Query(default=None),
+    source_group: str | None = Query(default=None),
+    policy_zone: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: SourceRegistryListResponse = SourceRegistryService(db).list_registry_entries(
+        product_id=product_id,
+        source_group=source_group,
+        policy_zone=policy_zone,
+        limit=limit,
+    )
+    return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/source_registry.py
+++ b/packages/contracts/source_registry.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field
+
+
+class SourceRegistryEntry(BaseModel):
+    source_id: str
+    vendor_id: str | None
+    product_id: str | None
+    root_url: str
+    source_family: str
+    source_group: str
+    source_type: str
+    policy_zone: str
+    connector_type: str
+    machine_readable: bool
+    crawler_mode: str
+    parser_chain: list[str] = Field(default_factory=list)
+    base_confidence_weight: float = Field(ge=0.0, le=1.0)
+    freshness_profile: str
+    refresh_cadence: str
+    provenance_required: bool = True
+    terms_review_required: bool = False
+    notes: str | None = None
+
+
+class SourceRegistryListResponse(BaseModel):
+    items: list[SourceRegistryEntry] = Field(default_factory=list)

--- a/packages/services/source_registry.py
+++ b/packages/services/source_registry.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from packages.contracts.source_registry import SourceRegistryEntry, SourceRegistryListResponse
+from packages.core.models import Source
+
+_MACHINE_READABLE_TYPES = {
+    "status_api",
+    "openapi",
+    "package_registry",
+    "docs_nav_json",
+    "jsonld_feed",
+    "sitemap",
+    "security_txt",
+}
+
+
+class SourceRegistryService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def list_registry_entries(self, *, product_id: str | None = None, source_group: str | None = None, policy_zone: str | None = None, limit: int = 200) -> SourceRegistryListResponse:
+        stmt = select(Source).order_by(Source.created_at.desc()).limit(limit)
+        if product_id:
+            from uuid import UUID
+            stmt = stmt.where(Source.product_id == UUID(product_id))
+
+        rows = self.db.execute(stmt).scalars()
+        items = [self._to_registry_entry(source) for source in rows]
+        if source_group:
+            items = [item for item in items if item.source_group == source_group]
+        if policy_zone:
+            items = [item for item in items if item.policy_zone == policy_zone]
+        return SourceRegistryListResponse(items=items)
+
+    def _to_registry_entry(self, source: Source) -> SourceRegistryEntry:
+        source_group = self._source_group(source)
+        policy_zone = self._policy_zone(source)
+        machine_readable = source.source_type in _MACHINE_READABLE_TYPES
+        return SourceRegistryEntry(
+            source_id=str(source.source_id),
+            vendor_id=str(source.vendor_id) if source.vendor_id else None,
+            product_id=str(source.product_id) if source.product_id else None,
+            root_url=source.root_url,
+            source_family=source.source_family,
+            source_group=source_group,
+            source_type=source.source_type,
+            policy_zone=policy_zone,
+            connector_type=source.connector_type,
+            machine_readable=machine_readable,
+            crawler_mode=self._crawler_mode(source, machine_readable),
+            parser_chain=self._parser_chain(source),
+            base_confidence_weight=self._base_confidence_weight(source_group, source.source_type),
+            freshness_profile=self._freshness_profile(source.source_type),
+            refresh_cadence=self._refresh_cadence(source.source_type),
+            provenance_required=True,
+            terms_review_required=policy_zone == "amber",
+            notes=self._notes(source),
+        )
+
+    def _source_group(self, source: Source) -> str:
+        if source.source_family == "vendor_owned":
+            if source.source_type in {"docs_subdomain", "docs_path", "developers_subdomain", "openapi"}:
+                return "developer_shipped_truth"
+            if source.source_type in {"status_page", "status_api", "trust_center", "security_txt"}:
+                return "operational_trust"
+            return "canonical_vendor_truth"
+        if source.source_family in {"package_registry", "repo", "marketplace", "partner_directory"}:
+            return "ecosystem_commercial"
+        if source.source_family in {"public_json", "machine_readable_public"}:
+            return "hidden_public_machine_readable"
+        return "ecosystem_commercial"
+
+    def _policy_zone(self, source: Source) -> str:
+        if source.source_family in {"public_json", "machine_readable_public"}:
+            return "amber"
+        return "green"
+
+    def _crawler_mode(self, source: Source, machine_readable: bool) -> str:
+        if machine_readable:
+            return "machine_readable_fetch"
+        if source.connector_type == "browser":
+            return "browser_fetch"
+        if source.connector_type == "api":
+            return "json_endpoint"
+        return "html_fetch"
+
+    def _parser_chain(self, source: Source) -> list[str]:
+        parser_chain: list[str] = []
+        if source.source_type == "sitemap":
+            parser_chain.append("sitemap_parser")
+        if source.source_type == "security_txt":
+            parser_chain.append("security_txt_parser")
+        if source.source_type == "openapi":
+            parser_chain.append("openapi_parser")
+        if source.source_type in {"docs_nav_json", "docs_subdomain", "docs_path", "developers_subdomain"}:
+            parser_chain.append("docs_nav_parser")
+        if source.source_type == "status_api":
+            parser_chain.append("statuspage_parser")
+        if source.source_family == "package_registry":
+            parser_chain.append("package_registry_parser")
+        parser_chain.append("html_claim_extractor")
+        return parser_chain
+
+    def _base_confidence_weight(self, source_group: str, source_type: str) -> float:
+        if source_group == "developer_shipped_truth":
+            return 0.92
+        if source_group == "canonical_vendor_truth":
+            return 0.9
+        if source_group == "operational_trust":
+            return 0.88
+        if source_type == "package_registry":
+            return 0.86
+        if source_group == "hidden_public_machine_readable":
+            return 0.72
+        return 0.68
+
+    def _freshness_profile(self, source_type: str) -> str:
+        if source_type in {"status_page", "status_api", "changelog", "release_notes"}:
+            return "high_volatility"
+        if source_type in {"pricing", "integrations_directory", "docs_subdomain", "docs_path"}:
+            return "medium_volatility"
+        return "low_volatility"
+
+    def _refresh_cadence(self, source_type: str) -> str:
+        if source_type in {"status_page", "status_api"}:
+            return "daily"
+        if source_type in {"pricing", "changelog", "release_notes", "docs_subdomain", "docs_path", "developers_subdomain", "integrations_directory"}:
+            return "weekly"
+        return "monthly"
+
+    def _notes(self, source: Source) -> str | None:
+        if self._policy_zone(source) == "amber":
+            return "Public but higher-scrutiny surface; require provenance logging and tighter rate control."
+        if source.source_type == "security_txt":
+            return "Use /.well-known/security.txt when available."
+        if source.source_type == "sitemap":
+            return "Use lastmod as freshness hint, not as sole truth signal."
+        return None

--- a/tests/test_admin_source_registry_routes.py
+++ b/tests/test_admin_source_registry_routes.py
@@ -1,0 +1,55 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.contracts.source_registry import SourceRegistryEntry, SourceRegistryListResponse
+from packages.core.deps import get_db
+
+
+class DummySourceRegistryService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def list_registry_entries(self, **kwargs):
+        return SourceRegistryListResponse(
+            items=[
+                SourceRegistryEntry(
+                    source_id="11111111-1111-1111-1111-111111111111",
+                    vendor_id=None,
+                    product_id="00000000-0000-0000-0000-000000000001",
+                    root_url="https://docs.example.com",
+                    source_family="vendor_owned",
+                    source_group="developer_shipped_truth",
+                    source_type="docs_subdomain",
+                    policy_zone="green",
+                    connector_type="browser",
+                    machine_readable=False,
+                    crawler_mode="browser_fetch",
+                    parser_chain=["docs_nav_parser", "html_claim_extractor"],
+                    base_confidence_weight=0.92,
+                    freshness_profile="medium_volatility",
+                    refresh_cadence="weekly",
+                    provenance_required=True,
+                    terms_review_required=False,
+                    notes=None,
+                )
+            ]
+        )
+
+
+def override_get_db():
+    yield object()
+
+
+def test_admin_source_registry_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_source_registry.SourceRegistryService", DummySourceRegistryService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.get("/v1/admin/source-registry?source_group=developer_shipped_truth&limit=10")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["items"][0]["source_group"] == "developer_shipped_truth"
+    assert body["items"][0]["parser_chain"][0] == "docs_nav_parser"
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## What this ships

Adds the first concrete source-registry foundation for the next acquisition architecture layer.

### Included
- `packages/contracts/source_registry.py`
- `packages/services/source_registry.py`
- `apps/api/routes/admin_source_registry.py`
- app wiring for `GET /v1/admin/source-registry`
- dedicated route coverage

## Scope
- classify existing `Source` records into:
  - source groups
  - policy zones
  - parser chains
  - crawler modes
  - confidence weights
  - freshness / refresh metadata
- expose the registry through an admin read surface

## Why now
This is the bridge from strategy into implementation. Discovery services and registry-manager orchestration need a real source-registry substrate to target.
