### PR TITLE
PR-019: add discovery group v1 with surface mapping and machine-readable finding

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 from apps.api.routes.admin import router as admin_router
 from apps.api.routes.admin_agent_ops import router as admin_agent_ops_router
+from apps.api.routes.admin_discovery import router as admin_discovery_router
 from apps.api.routes.admin_source_registry import router as admin_source_registry_router
 from apps.api.routes.agent_evals import router as agent_evals_router
 from apps.api.routes.agents import router as agents_router
@@ -23,6 +24,7 @@ app.include_router(vendors_router)
 app.include_router(admin_router)
 app.include_router(admin_agent_ops_router)
 app.include_router(admin_source_registry_router)
+app.include_router(admin_discovery_router)
 app.include_router(agent_evals_router)
 app.include_router(source_promotion_router)
 app.include_router(products_router)

--- a/apps/api/routes/admin_discovery.py
+++ b/apps/api/routes/admin_discovery.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from packages.contracts.api_common import ApiEnvelope
+from packages.contracts.discovery import DiscoveryRequest, DiscoveryResponse
+from packages.services.discovery_service import DiscoveryService
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+@router.post("/discovery/run", response_model=ApiEnvelope)
+def run_discovery(payload: DiscoveryRequest) -> ApiEnvelope:
+    result: DiscoveryResponse = DiscoveryService().discover(payload)
+    return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/discovery.py
+++ b/packages/contracts/discovery.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field
+
+
+class DiscoveryRequest(BaseModel):
+    vendor_domain: str
+    product_id: str | None = None
+    include_machine_readable: bool = True
+
+
+class DiscoveredSourceCandidate(BaseModel):
+    root_url: str
+    source_family: str
+    source_type: str
+    source_group: str
+    policy_zone: str
+    connector_type: str
+    machine_readable: bool
+    crawler_mode: str
+    parser_chain: list[str] = Field(default_factory=list)
+    base_confidence_weight: float = Field(ge=0.0, le=1.0)
+    provenance_required: bool = True
+    terms_review_required: bool = False
+    notes: str | None = None
+
+
+class DiscoveryResponse(BaseModel):
+    vendor_domain: str
+    candidates: list[DiscoveredSourceCandidate] = Field(default_factory=list)

--- a/packages/services/discovery/machine_readable_finder.py
+++ b/packages/services/discovery/machine_readable_finder.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from packages.contracts.discovery import DiscoveredSourceCandidate
+
+
+class MachineReadableFinderService:
+    def find(self, vendor_domain: str) -> list[DiscoveredSourceCandidate]:
+        base = vendor_domain.removeprefix("https://").removeprefix("http://").strip("/")
+        return [
+            self._candidate(f"https://{base}/robots.txt", "vendor_owned", "robots_txt", "canonical_vendor_truth", ["robots_parser"], 0.78, "Robots coordination surface."),
+            self._candidate(f"https://{base}/sitemap.xml", "vendor_owned", "sitemap", "canonical_vendor_truth", ["sitemap_parser"], 0.84, "Primary sitemap discovery surface."),
+            self._candidate(f"https://{base}/.well-known/security.txt", "vendor_owned", "security_txt", "operational_trust", ["security_txt_parser"], 0.88, "Machine-readable security disclosure surface."),
+            self._candidate(f"https://{base}/openapi.json", "vendor_owned", "openapi", "developer_shipped_truth", ["openapi_parser"], 0.92, "OpenAPI spec if exposed on main domain."),
+            self._candidate(f"https://docs.{base}/openapi.json", "vendor_owned", "openapi", "developer_shipped_truth", ["openapi_parser"], 0.92, "OpenAPI spec if exposed on docs domain."),
+            self._candidate(f"https://{base}/llms.txt", "machine_readable_public", "llms_txt", "hidden_public_machine_readable", ["llms_txt_parser"], 0.7, "AI-oriented site summary if present."),
+            self._candidate(f"https://{base}/manifest.json", "machine_readable_public", "docs_nav_json", "hidden_public_machine_readable", ["docs_nav_parser"], 0.72, "Common public manifest/bootstrap entrypoint."),
+        ]
+
+    def _candidate(self, root_url: str, source_family: str, source_type: str, source_group: str, parser_chain: list[str], weight: float, notes: str) -> DiscoveredSourceCandidate:
+        return DiscoveredSourceCandidate(
+            root_url=root_url,
+            source_family=source_family,
+            source_type=source_type,
+            source_group=source_group,
+            policy_zone="amber" if source_group == "hidden_public_machine_readable" else "green",
+            connector_type="api" if source_type in {"openapi", "docs_nav_json"} else "browser",
+            machine_readable=True,
+            crawler_mode="machine_readable_fetch",
+            parser_chain=parser_chain,
+            base_confidence_weight=weight,
+            provenance_required=True,
+            terms_review_required=source_group == "hidden_public_machine_readable",
+            notes=notes,
+        )

--- a/packages/services/discovery/surface_mapper.py
+++ b/packages/services/discovery/surface_mapper.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from packages.contracts.discovery import DiscoveredSourceCandidate
+
+
+class SurfaceMapperService:
+    def map_vendor_surfaces(self, vendor_domain: str) -> list[DiscoveredSourceCandidate]:
+        base = vendor_domain.removeprefix("https://").removeprefix("http://").strip("/")
+        candidates = [
+            self._candidate(f"https://{base}", "vendor_owned", "homepage", "canonical_vendor_truth", machine_readable=False, crawler_mode="html_fetch", parser_chain=["html_claim_extractor"], weight=0.9, notes="Primary vendor homepage."),
+            self._candidate(f"https://{base}/pricing", "vendor_owned", "pricing", "canonical_vendor_truth", machine_readable=False, crawler_mode="html_fetch", parser_chain=["html_claim_extractor"], weight=0.9, notes="Canonical pricing surface."),
+            self._candidate(f"https://docs.{base}", "vendor_owned", "docs_subdomain", "developer_shipped_truth", machine_readable=False, crawler_mode="browser_fetch", parser_chain=["docs_nav_parser", "html_claim_extractor"], weight=0.92, notes="Docs subdomain if present."),
+            self._candidate(f"https://{base}/docs", "vendor_owned", "docs_path", "developer_shipped_truth", machine_readable=False, crawler_mode="browser_fetch", parser_chain=["docs_nav_parser", "html_claim_extractor"], weight=0.9, notes="Docs path if docs live on main domain."),
+            self._candidate(f"https://developers.{base}", "vendor_owned", "developers_subdomain", "developer_shipped_truth", machine_readable=False, crawler_mode="browser_fetch", parser_chain=["docs_nav_parser", "html_claim_extractor"], weight=0.9, notes="Developer portal or API hub."),
+            self._candidate(f"https://{base}/integrations", "vendor_owned", "integrations_directory", "canonical_vendor_truth", machine_readable=False, crawler_mode="html_fetch", parser_chain=["html_claim_extractor"], weight=0.88, notes="Integrations directory if present."),
+            self._candidate(f"https://{base}/changelog", "vendor_owned", "changelog", "canonical_vendor_truth", machine_readable=False, crawler_mode="html_fetch", parser_chain=["html_claim_extractor"], weight=0.88, notes="Changelog or product updates surface."),
+            self._candidate(f"https://{base}/release-notes", "vendor_owned", "release_notes", "canonical_vendor_truth", machine_readable=False, crawler_mode="html_fetch", parser_chain=["html_claim_extractor"], weight=0.84, notes="Release notes surface if present."),
+            self._candidate(f"https://status.{base}", "vendor_owned", "status_page", "operational_trust", machine_readable=False, crawler_mode="html_fetch", parser_chain=["statuspage_parser", "html_claim_extractor"], weight=0.87, notes="Status page if vendor hosts one on subdomain."),
+            self._candidate(f"https://{base}/security", "vendor_owned", "trust_center", "operational_trust", machine_readable=False, crawler_mode="html_fetch", parser_chain=["html_claim_extractor"], weight=0.88, notes="Trust or security landing page."),
+        ]
+        return candidates
+
+    def _candidate(self, root_url: str, source_family: str, source_type: str, source_group: str, *, machine_readable: bool, crawler_mode: str, parser_chain: list[str], weight: float, notes: str | None) -> DiscoveredSourceCandidate:
+        return DiscoveredSourceCandidate(
+            root_url=root_url,
+            source_family=source_family,
+            source_type=source_type,
+            source_group=source_group,
+            policy_zone="green",
+            connector_type="browser",
+            machine_readable=machine_readable,
+            crawler_mode=crawler_mode,
+            parser_chain=parser_chain,
+            base_confidence_weight=weight,
+            provenance_required=True,
+            terms_review_required=False,
+            notes=notes,
+        )

--- a/packages/services/discovery_service.py
+++ b/packages/services/discovery_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from packages.contracts.discovery import DiscoveredSourceCandidate, DiscoveryRequest, DiscoveryResponse
+from packages.services.discovery.machine_readable_finder import MachineReadableFinderService
+from packages.services.discovery.surface_mapper import SurfaceMapperService
+
+
+class DiscoveryService:
+    def __init__(self) -> None:
+        self.surface_mapper = SurfaceMapperService()
+        self.machine_readable_finder = MachineReadableFinderService()
+
+    def discover(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        candidates: list[DiscoveredSourceCandidate] = []
+        candidates.extend(self.surface_mapper.map_vendor_surfaces(request.vendor_domain))
+        if request.include_machine_readable:
+            candidates.extend(self.machine_readable_finder.find(request.vendor_domain))
+
+        deduped: OrderedDict[str, DiscoveredSourceCandidate] = OrderedDict()
+        for candidate in candidates:
+            deduped[candidate.root_url] = candidate
+
+        return DiscoveryResponse(vendor_domain=request.vendor_domain, candidates=list(deduped.values()))

--- a/tests/test_admin_discovery_routes.py
+++ b/tests/test_admin_discovery_routes.py
@@ -1,0 +1,49 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+
+
+class DummyDiscoveryService:
+    def discover(self, payload):
+        return type(
+            "Resp",
+            (),
+            {
+                "model_dump": lambda self: {
+                    "vendor_domain": payload.vendor_domain,
+                    "candidates": [
+                        {
+                            "root_url": "https://docs.example.com",
+                            "source_family": "vendor_owned",
+                            "source_type": "docs_subdomain",
+                            "source_group": "developer_shipped_truth",
+                            "policy_zone": "green",
+                            "connector_type": "browser",
+                            "machine_readable": False,
+                            "crawler_mode": "browser_fetch",
+                            "parser_chain": ["docs_nav_parser", "html_claim_extractor"],
+                            "base_confidence_weight": 0.92,
+                            "provenance_required": True,
+                            "terms_review_required": False,
+                            "notes": "Docs subdomain if present.",
+                        }
+                    ],
+                }
+            },
+        )()
+
+
+def test_admin_discovery_run_returns_candidates(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_discovery.DiscoveryService", DummyDiscoveryService)
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/admin/discovery/run",
+        json={"vendor_domain": "example.com", "include_machine_readable": True},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["vendor_domain"] == "example.com"
+    assert body["candidates"][0]["source_group"] == "developer_shipped_truth"
+    assert body["candidates"][0]["root_url"] == "https://docs.example.com"


### PR DESCRIPTION
## What this ships

Adds the first Discovery Group checkpoint on top of the source-registry foundation.

### Included
- `packages/contracts/discovery.py`
- `packages/services/discovery/surface_mapper.py`
- `packages/services/discovery/machine_readable_finder.py`
- `packages/services/discovery_service.py`
- `apps/api/routes/admin_discovery.py`
- app wiring for `POST /v1/admin/discovery/run`
- dedicated route coverage

## Scope
- map likely vendor-owned surfaces from a domain
- propose machine-readable public discovery surfaces
- return registry-shaped source candidates without mutating core state
- provide a narrow admin trigger surface for discovery runs

## Why now
This is the next major checkpoint after the source-registry foundation. It gives BMT its first concrete discovery layer for source acquisition while keeping mutation and persistence out of scope for this slice.
