### PR TITLE
PR-020: add ecosystem discovery and registry-manager orchestration

### DIFF
--- a/apps/api/routes/admin_discovery.py
+++ b/apps/api/routes/admin_discovery.py
@@ -2,12 +2,12 @@ from fastapi import APIRouter
 
 from packages.contracts.api_common import ApiEnvelope
 from packages.contracts.discovery import DiscoveryRequest, DiscoveryResponse
-from packages.services.discovery_service import DiscoveryService
+from packages.services.registry_manager import RegistryManagerService
 
 router = APIRouter(prefix="/v1/admin", tags=["admin"])
 
 
 @router.post("/discovery/run", response_model=ApiEnvelope)
 def run_discovery(payload: DiscoveryRequest) -> ApiEnvelope:
-    result: DiscoveryResponse = DiscoveryService().discover(payload)
+    result: DiscoveryResponse = RegistryManagerService().run_discovery(payload)
     return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/discovery.py
+++ b/packages/contracts/discovery.py
@@ -5,6 +5,7 @@ class DiscoveryRequest(BaseModel):
     vendor_domain: str
     product_id: str | None = None
     include_machine_readable: bool = True
+    include_ecosystem: bool = True
 
 
 class DiscoveredSourceCandidate(BaseModel):
@@ -26,3 +27,4 @@ class DiscoveredSourceCandidate(BaseModel):
 class DiscoveryResponse(BaseModel):
     vendor_domain: str
     candidates: list[DiscoveredSourceCandidate] = Field(default_factory=list)
+    discovery_groups_run: list[str] = Field(default_factory=list)

--- a/packages/services/discovery/ecosystem_finder.py
+++ b/packages/services/discovery/ecosystem_finder.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from packages.contracts.discovery import DiscoveredSourceCandidate
+
+
+class EcosystemFinderService:
+    def find(self, vendor_domain: str) -> list[DiscoveredSourceCandidate]:
+        base = vendor_domain.removeprefix("https://").removeprefix("http://").strip("/")
+        vendor_slug = base.split(".")[0]
+        return [
+            self._candidate(f"https://github.com/{vendor_slug}", "repo", "official_repo_org", "ecosystem_commercial", "green", "api", False, "repo_api", ["repo_metadata_parser"], 0.84, "Likely public source-control organization if it exists."),
+            self._candidate(f"https://pypi.org/project/{vendor_slug}", "package_registry", "package_registry", "developer_shipped_truth", "green", "api", True, "registry_api", ["package_registry_parser"], 0.86, "Potential Python package namespace if vendor ships SDKs or CLI tools."),
+            self._candidate(f"https://www.npmjs.com/package/{vendor_slug}", "package_registry", "package_registry", "developer_shipped_truth", "green", "api", True, "registry_api", ["package_registry_parser"], 0.86, "Potential npm package namespace if vendor ships JS tooling or SDKs."),
+            self._candidate(f"https://www.g2.com/products/{vendor_slug}/reviews", "marketplace", "marketplace_listing", "ecosystem_commercial", "amber", "browser", False, "browser_fetch", ["html_claim_extractor"], 0.68, "Commercial marketplace signal; use with lower confidence and stronger provenance handling."),
+        ]
+
+    def _candidate(self, root_url: str, source_family: str, source_type: str, source_group: str, policy_zone: str, connector_type: str, machine_readable: bool, crawler_mode: str, parser_chain: list[str], weight: float, notes: str) -> DiscoveredSourceCandidate:
+        return DiscoveredSourceCandidate(
+            root_url=root_url,
+            source_family=source_family,
+            source_type=source_type,
+            source_group=source_group,
+            policy_zone=policy_zone,
+            connector_type=connector_type,
+            machine_readable=machine_readable,
+            crawler_mode=crawler_mode,
+            parser_chain=parser_chain,
+            base_confidence_weight=weight,
+            provenance_required=True,
+            terms_review_required=policy_zone == "amber",
+            notes=notes,
+        )

--- a/packages/services/registry_manager.py
+++ b/packages/services/registry_manager.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from packages.contracts.discovery import DiscoveredSourceCandidate, DiscoveryRequest, DiscoveryResponse
+from packages.services.discovery.ecosystem_finder import EcosystemFinderService
+from packages.services.discovery.machine_readable_finder import MachineReadableFinderService
+from packages.services.discovery.surface_mapper import SurfaceMapperService
+
+
+class RegistryManagerService:
+    def __init__(self) -> None:
+        self.surface_mapper = SurfaceMapperService()
+        self.machine_readable_finder = MachineReadableFinderService()
+        self.ecosystem_finder = EcosystemFinderService()
+
+    def run_discovery(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        groups_run: list[str] = []
+        candidates: list[DiscoveredSourceCandidate] = []
+
+        candidates.extend(self.surface_mapper.map_vendor_surfaces(request.vendor_domain))
+        groups_run.append("surface_mapper")
+
+        if request.include_machine_readable:
+            candidates.extend(self.machine_readable_finder.find(request.vendor_domain))
+            groups_run.append("machine_readable_finder")
+
+        if request.include_ecosystem:
+            candidates.extend(self.ecosystem_finder.find(request.vendor_domain))
+            groups_run.append("ecosystem_finder")
+
+        deduped: OrderedDict[str, DiscoveredSourceCandidate] = OrderedDict()
+        for candidate in candidates:
+            deduped[candidate.root_url] = candidate
+
+        return DiscoveryResponse(
+            vendor_domain=request.vendor_domain,
+            candidates=list(deduped.values()),
+            discovery_groups_run=groups_run,
+        )

--- a/tests/test_admin_discovery_routes.py
+++ b/tests/test_admin_discovery_routes.py
@@ -3,14 +3,15 @@ from fastapi.testclient import TestClient
 from apps.api.main import app
 
 
-class DummyDiscoveryService:
-    def discover(self, payload):
+class DummyRegistryManagerService:
+    def run_discovery(self, payload):
         return type(
             "Resp",
             (),
             {
                 "model_dump": lambda self: {
                     "vendor_domain": payload.vendor_domain,
+                    "discovery_groups_run": ["surface_mapper", "machine_readable_finder", "ecosystem_finder"],
                     "candidates": [
                         {
                             "root_url": "https://docs.example.com",
@@ -26,6 +27,21 @@ class DummyDiscoveryService:
                             "provenance_required": True,
                             "terms_review_required": False,
                             "notes": "Docs subdomain if present.",
+                        },
+                        {
+                            "root_url": "https://github.com/example",
+                            "source_family": "repo",
+                            "source_type": "official_repo_org",
+                            "source_group": "ecosystem_commercial",
+                            "policy_zone": "green",
+                            "connector_type": "api",
+                            "machine_readable": False,
+                            "crawler_mode": "repo_api",
+                            "parser_chain": ["repo_metadata_parser"],
+                            "base_confidence_weight": 0.84,
+                            "provenance_required": True,
+                            "terms_review_required": False,
+                            "notes": "Likely public source-control organization if it exists.",
                         }
                     ],
                 }
@@ -33,17 +49,18 @@ class DummyDiscoveryService:
         )()
 
 
-def test_admin_discovery_run_returns_candidates(monkeypatch) -> None:
-    monkeypatch.setattr("apps.api.routes.admin_discovery.DiscoveryService", DummyDiscoveryService)
+def test_admin_discovery_run_returns_candidates_and_groups(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_discovery.RegistryManagerService", DummyRegistryManagerService)
     client = TestClient(app)
 
     response = client.post(
         "/v1/admin/discovery/run",
-        json={"vendor_domain": "example.com", "include_machine_readable": True},
+        json={"vendor_domain": "example.com", "include_machine_readable": True, "include_ecosystem": True},
     )
 
     assert response.status_code == 200
     body = response.json()["data"]
     assert body["vendor_domain"] == "example.com"
-    assert body["candidates"][0]["source_group"] == "developer_shipped_truth"
-    assert body["candidates"][0]["root_url"] == "https://docs.example.com"
+    assert body["discovery_groups_run"] == ["surface_mapper", "machine_readable_finder", "ecosystem_finder"]
+    assert body["candidates"][1]["source_group"] == "ecosystem_commercial"
+    assert body["candidates"][1]["root_url"] == "https://github.com/example"


### PR DESCRIPTION
## What this ships

Extends the Discovery Group with ecosystem discovery and a manager-style orchestration layer.

### Included
- `packages/services/discovery/ecosystem_finder.py`
- `packages/services/registry_manager.py`
- discovery contract extension for `include_ecosystem` and `discovery_groups_run`
- admin discovery route updated to run through the registry manager
- expanded route coverage

## Scope
- add ecosystem-oriented public source candidates (repo org, package registries, marketplace)
- orchestrate surface mapping, machine-readable discovery, and ecosystem discovery through one manager service
- return which discovery groups ran in the response

## Why now
This is the next major checkpoint after Discovery Group v1. It moves discovery from a pair of helpers toward a real subsystem with explicit orchestration and broader public-source coverage.
