### PR TITLE
PR-021: persist discovery runs and add admin history surface

### DIFF
--- a/apps/api/routes/admin_agent_ops.py
+++ b/apps/api/routes/admin_agent_ops.py
@@ -9,6 +9,7 @@ from packages.contracts.admin import (
 from packages.contracts.api_common import ApiEnvelope
 from packages.core.deps import get_db
 from packages.services.admin_queries import AdminQueryService
+from packages.services.registry_manager import DISCOVERY_AGENT_NAME
 
 router = APIRouter(prefix="/v1/admin", tags=["admin"])
 
@@ -24,6 +25,24 @@ def list_agent_runs(
 ) -> ApiEnvelope:
     result: AgentRunListResponse = AdminQueryService(db).list_agent_runs(
         agent_name=agent_name,
+        product_id=product_id,
+        status=status,
+        trace_id=trace_id,
+        limit=limit,
+    )
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.get("/discovery-runs", response_model=ApiEnvelope)
+def list_discovery_runs(
+    product_id: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    trace_id: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: AgentRunListResponse = AdminQueryService(db).list_agent_runs(
+        agent_name=DISCOVERY_AGENT_NAME,
         product_id=product_id,
         status=status,
         trace_id=trace_id,

--- a/apps/api/routes/admin_discovery.py
+++ b/apps/api/routes/admin_discovery.py
@@ -1,13 +1,15 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
 
 from packages.contracts.api_common import ApiEnvelope
 from packages.contracts.discovery import DiscoveryRequest, DiscoveryResponse
+from packages.core.deps import get_db
 from packages.services.registry_manager import RegistryManagerService
 
 router = APIRouter(prefix="/v1/admin", tags=["admin"])
 
 
 @router.post("/discovery/run", response_model=ApiEnvelope)
-def run_discovery(payload: DiscoveryRequest) -> ApiEnvelope:
-    result: DiscoveryResponse = RegistryManagerService().run_discovery(payload)
+def run_discovery(payload: DiscoveryRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: DiscoveryResponse = RegistryManagerService(db).run_discovery(payload)
     return ApiEnvelope(data=result.model_dump())

--- a/packages/services/registry_manager.py
+++ b/packages/services/registry_manager.py
@@ -2,14 +2,22 @@ from __future__ import annotations
 
 from collections import OrderedDict
 
+from sqlalchemy.orm import Session
+
 from packages.contracts.discovery import DiscoveredSourceCandidate, DiscoveryRequest, DiscoveryResponse
+from packages.services.agent_run_store import AgentRunStore
 from packages.services.discovery.ecosystem_finder import EcosystemFinderService
 from packages.services.discovery.machine_readable_finder import MachineReadableFinderService
 from packages.services.discovery.surface_mapper import SurfaceMapperService
 
+DISCOVERY_AGENT_NAME = "registry_manager_discovery"
+DISCOVERY_STRATEGY_VERSION = "discovery_v1"
+
 
 class RegistryManagerService:
-    def __init__(self) -> None:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.agent_run_store = AgentRunStore(db)
         self.surface_mapper = SurfaceMapperService()
         self.machine_readable_finder = MachineReadableFinderService()
         self.ecosystem_finder = EcosystemFinderService()
@@ -33,8 +41,19 @@ class RegistryManagerService:
         for candidate in candidates:
             deduped[candidate.root_url] = candidate
 
-        return DiscoveryResponse(
+        response = DiscoveryResponse(
             vendor_domain=request.vendor_domain,
             candidates=list(deduped.values()),
             discovery_groups_run=groups_run,
         )
+        self.agent_run_store.create_agent_run(
+            agent_name=DISCOVERY_AGENT_NAME,
+            strategy_version=DISCOVERY_STRATEGY_VERSION,
+            mode="manager_orchestrated_discovery",
+            product_id=request.product_id,
+            vendor_id=None,
+            request_payload=request.model_dump(),
+            response_payload=response.model_dump(),
+        )
+        self.db.commit()
+        return response

--- a/tests/test_admin_discovery_routes.py
+++ b/tests/test_admin_discovery_routes.py
@@ -1,9 +1,13 @@
 from fastapi.testclient import TestClient
 
 from apps.api.main import app
+from packages.core.deps import get_db
 
 
 class DummyRegistryManagerService:
+    def __init__(self, _db: object) -> None:
+        pass
+
     def run_discovery(self, payload):
         return type(
             "Resp",
@@ -49,8 +53,13 @@ class DummyRegistryManagerService:
         )()
 
 
+def override_get_db():
+    yield object()
+
+
 def test_admin_discovery_run_returns_candidates_and_groups(monkeypatch) -> None:
     monkeypatch.setattr("apps.api.routes.admin_discovery.RegistryManagerService", DummyRegistryManagerService)
+    app.dependency_overrides[get_db] = override_get_db
     client = TestClient(app)
 
     response = client.post(
@@ -64,3 +73,5 @@ def test_admin_discovery_run_returns_candidates_and_groups(monkeypatch) -> None:
     assert body["discovery_groups_run"] == ["surface_mapper", "machine_readable_finder", "ecosystem_finder"]
     assert body["candidates"][1]["source_group"] == "ecosystem_commercial"
     assert body["candidates"][1]["root_url"] == "https://github.com/example"
+
+    app.dependency_overrides.clear()

--- a/tests/test_discovery_runs_history_routes.py
+++ b/tests/test_discovery_runs_history_routes.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.core.deps import get_db
+
+
+class DummyAdminQueryService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def list_agent_runs(self, **kwargs):
+        now = datetime.now(timezone.utc)
+        return type(
+            "Resp",
+            (),
+            {
+                "model_dump": lambda self: {
+                    "items": [
+                        {
+                            "agent_run_id": "11111111-1111-1111-1111-111111111111",
+                            "agent_name": "registry_manager_discovery",
+                            "strategy_version": "discovery_v1",
+                            "mode": "manager_orchestrated_discovery",
+                            "status": "completed",
+                            "trace_id": "trace-1",
+                            "request_id": "request-1",
+                            "product_id": None,
+                            "vendor_id": None,
+                            "created_at": now.isoformat(),
+                            "updated_at": now.isoformat(),
+                        }
+                    ]
+                }
+            },
+        )()
+
+
+def override_get_db():
+    yield object()
+
+
+def test_admin_discovery_runs_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_agent_ops.AdminQueryService", DummyAdminQueryService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.get("/v1/admin/discovery-runs?limit=10")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["items"][0]["agent_name"] == "registry_manager_discovery"
+    assert body["items"][0]["mode"] == "manager_orchestrated_discovery"
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## What this ships

Turns discovery from a manual trigger into an operational subsystem with persisted run history.

### Included
- registry manager now persists discovery runs through the existing agent-run store
- admin discovery trigger now uses a DB-backed registry manager
- `GET /v1/admin/discovery-runs`
- route coverage for persisted discovery trigger and discovery history

## Scope
- write discovery runs into the existing `agent_runs` persistence path
- standardize discovery history under agent operations rather than creating a new table immediately
- expose discovery-run history through a dedicated admin read surface

## Why now
This is the next major checkpoint after discovery orchestration. It gives discovery an operational memory and makes it inspectable the same way the rest of the agent system is inspectable.
