### PR TITLE
PR-023: add first-class discovery candidates and review actions

### DIFF
--- a/apps/api/routes/admin_discovery_review.py
+++ b/apps/api/routes/admin_discovery_review.py
@@ -2,7 +2,11 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from packages.contracts.api_common import ApiEnvelope
-from packages.contracts.discovery_review import DiscoveryCandidateReviewListResponse
+from packages.contracts.discovery_review import (
+    DiscoveryCandidateDecisionRequest,
+    DiscoveryCandidateDecisionResponse,
+    DiscoveryCandidateReviewListResponse,
+)
 from packages.core.deps import get_db
 from packages.services.discovery_review import DiscoveryReviewService
 
@@ -14,6 +18,7 @@ def list_discovery_candidates(
     vendor_domain: str | None = Query(default=None),
     source_group: str | None = Query(default=None),
     policy_zone: str | None = Query(default=None),
+    review_status: str | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=500),
     db: Session = Depends(get_db),
 ) -> ApiEnvelope:
@@ -21,6 +26,33 @@ def list_discovery_candidates(
         vendor_domain=vendor_domain,
         source_group=source_group,
         policy_zone=policy_zone,
+        review_status=review_status,
         limit=limit,
+    )
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.post("/discovery-candidates/{discovery_candidate_id}/approve", response_model=ApiEnvelope)
+def approve_discovery_candidate(
+    discovery_candidate_id: str,
+    payload: DiscoveryCandidateDecisionRequest,
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: DiscoveryCandidateDecisionResponse = DiscoveryReviewService(db).approve_candidate(
+        discovery_candidate_id=discovery_candidate_id,
+        reviewer_note=payload.reviewer_note,
+    )
+    return ApiEnvelope(data=result.model_dump())
+
+
+@router.post("/discovery-candidates/{discovery_candidate_id}/reject", response_model=ApiEnvelope)
+def reject_discovery_candidate(
+    discovery_candidate_id: str,
+    payload: DiscoveryCandidateDecisionRequest,
+    db: Session = Depends(get_db),
+) -> ApiEnvelope:
+    result: DiscoveryCandidateDecisionResponse = DiscoveryReviewService(db).reject_candidate(
+        discovery_candidate_id=discovery_candidate_id,
+        reviewer_note=payload.reviewer_note,
     )
     return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/discovery_review.py
+++ b/packages/contracts/discovery_review.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 
 
 class DiscoveryCandidateReviewItem(BaseModel):
+    discovery_candidate_id: str
     discovery_run_id: str
     vendor_domain: str
     root_url: str
@@ -18,10 +19,28 @@ class DiscoveryCandidateReviewItem(BaseModel):
     base_confidence_weight: float
     provenance_required: bool = True
     terms_review_required: bool = False
+    review_status: str
+    reviewer_note: str | None = None
     notes: str | None = None
+    promoted_source_id: str | None = None
     trace_id: str | None = None
+    approved_at: datetime | None = None
+    rejected_at: datetime | None = None
     created_at: datetime
+    updated_at: datetime
 
 
 class DiscoveryCandidateReviewListResponse(BaseModel):
     items: list[DiscoveryCandidateReviewItem] = Field(default_factory=list)
+
+
+class DiscoveryCandidateDecisionResponse(BaseModel):
+    discovery_candidate_id: str
+    review_status: str
+    reviewer_note: str | None = None
+    approved_at: datetime | None = None
+    rejected_at: datetime | None = None
+
+
+class DiscoveryCandidateDecisionRequest(BaseModel):
+    reviewer_note: str | None = None

--- a/packages/core/models.py
+++ b/packages/core/models.py
@@ -150,6 +150,34 @@ class AgentRun(TimestampMixin, Base):
     error_message: Mapped[str | None] = mapped_column(Text)
 
 
+class DiscoveryCandidate(TimestampMixin, Base):
+    __tablename__ = "discovery_candidates"
+
+    discovery_candidate_id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    discovery_run_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("agent_runs.agent_run_id"), nullable=False)
+    product_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("products.product_id"))
+    promoted_source_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("sources.source_id"))
+    vendor_domain: Mapped[str] = mapped_column(String(255), nullable=False)
+    root_url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    source_family: Mapped[str] = mapped_column(String(100), nullable=False)
+    source_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    source_group: Mapped[str] = mapped_column(String(100), nullable=False)
+    policy_zone: Mapped[str] = mapped_column(String(50), nullable=False)
+    connector_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    machine_readable: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    crawler_mode: Mapped[str] = mapped_column(String(100), nullable=False)
+    parser_chain: Mapped[list] = mapped_column(JSONB, default=list, nullable=False)
+    base_confidence_weight: Mapped[float] = mapped_column(Float, default=0.5, nullable=False)
+    provenance_required: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    terms_review_required: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    review_status: Mapped[str] = mapped_column(String(50), default="pending", nullable=False)
+    reviewer_note: Mapped[str | None] = mapped_column(Text)
+    notes: Mapped[str | None] = mapped_column(Text)
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    candidate_metadata: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+
+
 class AgentEvalRun(TimestampMixin, Base):
     __tablename__ = "agent_eval_runs"
 

--- a/packages/services/discovery_review.py
+++ b/packages/services/discovery_review.py
@@ -1,19 +1,58 @@
 from __future__ import annotations
 
+import uuid
+from datetime import datetime, timezone
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from packages.contracts.discovery import DiscoveredSourceCandidate
 from packages.contracts.discovery_review import (
+    DiscoveryCandidateDecisionResponse,
     DiscoveryCandidateReviewItem,
     DiscoveryCandidateReviewListResponse,
 )
-from packages.core.models import AgentRun
-from packages.services.registry_manager import DISCOVERY_AGENT_NAME
+from packages.core.models import DiscoveryCandidate
 
 
 class DiscoveryReviewService:
     def __init__(self, db: Session) -> None:
         self.db = db
+
+    def create_candidates(
+        self,
+        *,
+        discovery_run_id: str,
+        product_id: str | None,
+        vendor_domain: str,
+        candidates: list[DiscoveredSourceCandidate],
+    ) -> list[DiscoveryCandidate]:
+        created: list[DiscoveryCandidate] = []
+        for candidate in candidates:
+            record = DiscoveryCandidate(
+                discovery_run_id=uuid.UUID(discovery_run_id),
+                product_id=uuid.UUID(product_id) if product_id else None,
+                vendor_domain=vendor_domain,
+                root_url=candidate.root_url,
+                source_family=candidate.source_family,
+                source_type=candidate.source_type,
+                source_group=candidate.source_group,
+                policy_zone=candidate.policy_zone,
+                connector_type=candidate.connector_type,
+                machine_readable=candidate.machine_readable,
+                crawler_mode=candidate.crawler_mode,
+                parser_chain=candidate.parser_chain,
+                base_confidence_weight=candidate.base_confidence_weight,
+                provenance_required=candidate.provenance_required,
+                terms_review_required=candidate.terms_review_required,
+                notes=candidate.notes,
+                review_status="pending",
+                candidate_metadata={},
+            )
+            self.db.add(record)
+            created.append(record)
+        self.db.flush()
+        return created
 
     def list_candidates(
         self,
@@ -21,51 +60,80 @@ class DiscoveryReviewService:
         vendor_domain: str | None,
         source_group: str | None,
         policy_zone: str | None,
+        review_status: str | None,
         limit: int,
     ) -> DiscoveryCandidateReviewListResponse:
-        stmt = (
-            select(AgentRun)
-            .where(AgentRun.agent_name == DISCOVERY_AGENT_NAME)
-            .order_by(AgentRun.created_at.desc())
-            .limit(limit)
-        )
-        runs = self.db.execute(stmt).scalars()
+        stmt = select(DiscoveryCandidate).order_by(DiscoveryCandidate.created_at.desc()).limit(limit)
+        if vendor_domain:
+            stmt = stmt.where(DiscoveryCandidate.vendor_domain == vendor_domain)
+        if source_group:
+            stmt = stmt.where(DiscoveryCandidate.source_group == source_group)
+        if policy_zone:
+            stmt = stmt.where(DiscoveryCandidate.policy_zone == policy_zone)
+        if review_status:
+            stmt = stmt.where(DiscoveryCandidate.review_status == review_status)
 
-        items: list[DiscoveryCandidateReviewItem] = []
-        seen: set[tuple[str, str]] = set()
-        for run in runs:
-            response_payload = run.response_payload or {}
-            run_vendor_domain = response_payload.get("vendor_domain")
-            if vendor_domain and run_vendor_domain != vendor_domain:
-                continue
-            for candidate in response_payload.get("candidates", []):
-                if source_group and candidate.get("source_group") != source_group:
-                    continue
-                if policy_zone and candidate.get("policy_zone") != policy_zone:
-                    continue
-                dedupe_key = (run_vendor_domain or "", candidate.get("root_url") or "")
-                if dedupe_key in seen:
-                    continue
-                seen.add(dedupe_key)
-                items.append(
-                    DiscoveryCandidateReviewItem(
-                        discovery_run_id=str(run.agent_run_id),
-                        vendor_domain=run_vendor_domain or "",
-                        root_url=candidate.get("root_url", ""),
-                        source_family=candidate.get("source_family", ""),
-                        source_type=candidate.get("source_type", ""),
-                        source_group=candidate.get("source_group", ""),
-                        policy_zone=candidate.get("policy_zone", ""),
-                        connector_type=candidate.get("connector_type", ""),
-                        machine_readable=bool(candidate.get("machine_readable", False)),
-                        crawler_mode=candidate.get("crawler_mode", ""),
-                        parser_chain=list(candidate.get("parser_chain", [])),
-                        base_confidence_weight=float(candidate.get("base_confidence_weight", 0.0)),
-                        provenance_required=bool(candidate.get("provenance_required", True)),
-                        terms_review_required=bool(candidate.get("terms_review_required", False)),
-                        notes=candidate.get("notes"),
-                        trace_id=run.trace_id,
-                        created_at=run.created_at,
-                    )
-                )
+        rows = self.db.execute(stmt).scalars()
+        items = [self._to_item(candidate) for candidate in rows]
         return DiscoveryCandidateReviewListResponse(items=items)
+
+    def approve_candidate(self, discovery_candidate_id: str, reviewer_note: str | None) -> DiscoveryCandidateDecisionResponse:
+        candidate = self._get_candidate(discovery_candidate_id)
+        candidate.review_status = "approved"
+        candidate.reviewer_note = reviewer_note
+        candidate.approved_at = datetime.now(timezone.utc)
+        candidate.rejected_at = None
+        self.db.commit()
+        return self._decision_response(candidate)
+
+    def reject_candidate(self, discovery_candidate_id: str, reviewer_note: str | None) -> DiscoveryCandidateDecisionResponse:
+        candidate = self._get_candidate(discovery_candidate_id)
+        candidate.review_status = "rejected"
+        candidate.reviewer_note = reviewer_note
+        candidate.rejected_at = datetime.now(timezone.utc)
+        candidate.approved_at = None
+        self.db.commit()
+        return self._decision_response(candidate)
+
+    def _get_candidate(self, discovery_candidate_id: str) -> DiscoveryCandidate:
+        candidate = self.db.execute(
+            select(DiscoveryCandidate).where(DiscoveryCandidate.discovery_candidate_id == uuid.UUID(discovery_candidate_id))
+        ).scalar_one()
+        return candidate
+
+    def _decision_response(self, candidate: DiscoveryCandidate) -> DiscoveryCandidateDecisionResponse:
+        return DiscoveryCandidateDecisionResponse(
+            discovery_candidate_id=str(candidate.discovery_candidate_id),
+            review_status=candidate.review_status,
+            reviewer_note=candidate.reviewer_note,
+            approved_at=candidate.approved_at,
+            rejected_at=candidate.rejected_at,
+        )
+
+    def _to_item(self, candidate: DiscoveryCandidate) -> DiscoveryCandidateReviewItem:
+        return DiscoveryCandidateReviewItem(
+            discovery_candidate_id=str(candidate.discovery_candidate_id),
+            discovery_run_id=str(candidate.discovery_run_id),
+            vendor_domain=candidate.vendor_domain,
+            root_url=candidate.root_url,
+            source_family=candidate.source_family,
+            source_type=candidate.source_type,
+            source_group=candidate.source_group,
+            policy_zone=candidate.policy_zone,
+            connector_type=candidate.connector_type,
+            machine_readable=candidate.machine_readable,
+            crawler_mode=candidate.crawler_mode,
+            parser_chain=list(candidate.parser_chain or []),
+            base_confidence_weight=candidate.base_confidence_weight,
+            provenance_required=candidate.provenance_required,
+            terms_review_required=candidate.terms_review_required,
+            review_status=candidate.review_status,
+            reviewer_note=candidate.reviewer_note,
+            notes=candidate.notes,
+            promoted_source_id=str(candidate.promoted_source_id) if candidate.promoted_source_id else None,
+            trace_id=None,
+            approved_at=candidate.approved_at,
+            rejected_at=candidate.rejected_at,
+            created_at=candidate.created_at,
+            updated_at=candidate.updated_at,
+        )

--- a/packages/services/registry_manager.py
+++ b/packages/services/registry_manager.py
@@ -9,6 +9,7 @@ from packages.services.agent_run_store import AgentRunStore
 from packages.services.discovery.ecosystem_finder import EcosystemFinderService
 from packages.services.discovery.machine_readable_finder import MachineReadableFinderService
 from packages.services.discovery.surface_mapper import SurfaceMapperService
+from packages.services.discovery_review import DiscoveryReviewService
 
 DISCOVERY_AGENT_NAME = "registry_manager_discovery"
 DISCOVERY_STRATEGY_VERSION = "discovery_v1"
@@ -18,6 +19,7 @@ class RegistryManagerService:
     def __init__(self, db: Session) -> None:
         self.db = db
         self.agent_run_store = AgentRunStore(db)
+        self.discovery_review = DiscoveryReviewService(db)
         self.surface_mapper = SurfaceMapperService()
         self.machine_readable_finder = MachineReadableFinderService()
         self.ecosystem_finder = EcosystemFinderService()
@@ -46,7 +48,7 @@ class RegistryManagerService:
             candidates=list(deduped.values()),
             discovery_groups_run=groups_run,
         )
-        self.agent_run_store.create_agent_run(
+        run = self.agent_run_store.create_agent_run(
             agent_name=DISCOVERY_AGENT_NAME,
             strategy_version=DISCOVERY_STRATEGY_VERSION,
             mode="manager_orchestrated_discovery",
@@ -54,6 +56,12 @@ class RegistryManagerService:
             vendor_id=None,
             request_payload=request.model_dump(),
             response_payload=response.model_dump(),
+        )
+        self.discovery_review.create_candidates(
+            discovery_run_id=str(run.agent_run_id),
+            product_id=request.product_id,
+            vendor_domain=request.vendor_domain,
+            candidates=response.candidates,
         )
         self.db.commit()
         return response

--- a/tests/test_admin_discovery_review_routes.py
+++ b/tests/test_admin_discovery_review_routes.py
@@ -19,6 +19,7 @@ class DummyDiscoveryReviewService:
                 "model_dump": lambda self: {
                     "items": [
                         {
+                            "discovery_candidate_id": "22222222-2222-2222-2222-222222222222",
                             "discovery_run_id": "11111111-1111-1111-1111-111111111111",
                             "vendor_domain": "example.com",
                             "root_url": "https://docs.example.com",
@@ -33,11 +34,49 @@ class DummyDiscoveryReviewService:
                             "base_confidence_weight": 0.92,
                             "provenance_required": True,
                             "terms_review_required": False,
+                            "review_status": "pending",
+                            "reviewer_note": None,
                             "notes": "Docs subdomain if present.",
+                            "promoted_source_id": None,
                             "trace_id": "trace-1",
+                            "approved_at": None,
+                            "rejected_at": None,
                             "created_at": now.isoformat(),
+                            "updated_at": now.isoformat(),
                         }
                     ]
+                }
+            },
+        )()
+
+    def approve_candidate(self, discovery_candidate_id: str, reviewer_note: str | None):
+        now = datetime.now(timezone.utc)
+        return type(
+            "Resp",
+            (),
+            {
+                "model_dump": lambda self: {
+                    "discovery_candidate_id": discovery_candidate_id,
+                    "review_status": "approved",
+                    "reviewer_note": reviewer_note,
+                    "approved_at": now.isoformat(),
+                    "rejected_at": None,
+                }
+            },
+        )()
+
+    def reject_candidate(self, discovery_candidate_id: str, reviewer_note: str | None):
+        now = datetime.now(timezone.utc)
+        return type(
+            "Resp",
+            (),
+            {
+                "model_dump": lambda self: {
+                    "discovery_candidate_id": discovery_candidate_id,
+                    "review_status": "rejected",
+                    "reviewer_note": reviewer_note,
+                    "approved_at": None,
+                    "rejected_at": now.isoformat(),
                 }
             },
         )()
@@ -52,12 +91,48 @@ def test_admin_discovery_candidates_endpoint_returns_payload(monkeypatch) -> Non
     app.dependency_overrides[get_db] = override_get_db
     client = TestClient(app)
 
-    response = client.get("/v1/admin/discovery-candidates?vendor_domain=example.com&limit=10")
+    response = client.get("/v1/admin/discovery-candidates?vendor_domain=example.com&review_status=pending&limit=10")
 
     assert response.status_code == 200
     body = response.json()["data"]
     assert body["items"][0]["vendor_domain"] == "example.com"
     assert body["items"][0]["source_group"] == "developer_shipped_truth"
-    assert body["items"][0]["root_url"] == "https://docs.example.com"
+    assert body["items"][0]["review_status"] == "pending"
+
+    app.dependency_overrides.clear()
+
+
+def test_admin_discovery_candidate_approve_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_discovery_review.DiscoveryReviewService", DummyDiscoveryReviewService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/admin/discovery-candidates/22222222-2222-2222-2222-222222222222/approve",
+        json={"reviewer_note": "High-signal docs surface."},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["review_status"] == "approved"
+    assert body["reviewer_note"] == "High-signal docs surface."
+
+    app.dependency_overrides.clear()
+
+
+def test_admin_discovery_candidate_reject_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_discovery_review.DiscoveryReviewService", DummyDiscoveryReviewService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/admin/discovery-candidates/22222222-2222-2222-2222-222222222222/reject",
+        json={"reviewer_note": "Duplicate or low-value candidate."},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["review_status"] == "rejected"
+    assert body["reviewer_note"] == "Duplicate or low-value candidate."
 
     app.dependency_overrides.clear()


### PR DESCRIPTION
## What this ships

Creates the first real workflow object model for discovery outputs and adds stateful review actions.

### Included
- `DiscoveryCandidate` model in `packages/core/models.py`
- discovery review contracts expanded for first-class candidates and decision responses
- `DiscoveryReviewService` now persists, lists, approves, and rejects candidates
- `RegistryManagerService` now creates `DiscoveryCandidate` records during discovery runs
- admin review surface expanded with:
  - `GET /v1/admin/discovery-candidates`
  - `POST /v1/admin/discovery-candidates/{id}/approve`
  - `POST /v1/admin/discovery-candidates/{id}/reject`
- route coverage for list / approve / reject flows

## Scope
- replace review-as-projection with real candidate workflow objects
- keep candidate state explicit (`pending`, `approved`, `rejected`)
- preserve the current discovery flow while making downstream review and promotion much more operable

## Why now
This is the next major checkpoint after discovery history and candidate review. It upgrades discovery from a derived review view into a true acquisition workflow foundation.
