### PR TITLE
PR-024: add planner feedback signals for evidence yield and gap closure

### DIFF
--- a/packages/services/evidence_yield.py
+++ b/packages/services/evidence_yield.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from packages.core.models import Evidence, Page
+
+
+class EvidenceYieldService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def compute(self, source_id: str | uuid.UUID) -> float:
+        source_uuid = uuid.UUID(str(source_id))
+        evidence_count = int(
+            self.db.execute(
+                select(func.count(Evidence.evidence_id)).where(Evidence.source_id == source_uuid)
+            ).scalar_one()
+            or 0
+        )
+        if evidence_count == 0:
+            return 0.0
+
+        avg_confidence = float(
+            self.db.execute(
+                select(func.avg(Evidence.confidence)).where(Evidence.source_id == source_uuid)
+            ).scalar_one()
+            or 0.0
+        )
+        unique_pages = int(
+            self.db.execute(
+                select(func.count(func.distinct(Evidence.page_id))).where(Evidence.source_id == source_uuid)
+            ).scalar_one()
+            or 0
+        )
+        docs_pages = int(
+            self.db.execute(
+                select(func.count(Page.page_id))
+                .where(Page.source_id == source_uuid)
+                .where(Page.page_type.in_(["docs", "api_reference", "pricing", "changelog"]))
+            ).scalar_one()
+            or 0
+        )
+
+        count_score = min(evidence_count / 12.0, 1.0)
+        page_score = min(unique_pages / 4.0, 1.0)
+        docs_score = min(docs_pages / 3.0, 1.0)
+        score = (count_score * 0.35) + (avg_confidence * 0.4) + (page_score * 0.15) + (docs_score * 0.1)
+        return round(min(score, 1.0), 3)

--- a/packages/services/gap_closure.py
+++ b/packages/services/gap_closure.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from packages.core.models import Source
+from packages.services.gap_detector import detect_product_gaps
+from packages.services.product_intelligence import ProductIntelligenceService, build_normalized_claims
+
+
+class GapClosureService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+        self.product_intelligence = ProductIntelligenceService(db)
+
+    def compute(self, product_id: str | uuid.UUID, source_id: str | uuid.UUID) -> float:
+        product_uuid = uuid.UUID(str(product_id))
+        source_uuid = uuid.UUID(str(source_id))
+        source = self.db.execute(select(Source).where(Source.source_id == source_uuid)).scalar_one_or_none()
+        if source is None:
+            return 0.0
+
+        rows = self.product_intelligence._get_claim_rows(product_uuid)
+        claims = build_normalized_claims(rows=rows, min_confidence=0.0, include_stale=True, include_evidence=False)
+        page_types = self.product_intelligence._get_page_types(product_uuid)
+        gaps = detect_product_gaps(page_types=page_types, claims=claims)
+        gap_codes = {gap.gap_code for gap in gaps}
+
+        score = 0.0
+        if source.source_type == "pricing" and "missing_pricing_page" not in gap_codes:
+            score += 0.35
+        if source.source_type in {"docs_subdomain", "docs_path", "developers_subdomain"} and "missing_docs_surface" not in gap_codes:
+            score += 0.35
+        if source.source_type in {"changelog", "release_notes"} and "missing_change_surface" not in gap_codes:
+            score += 0.2
+        if source.source_type == "integrations_directory" and "integrations_thin_support" not in gap_codes:
+            score += 0.2
+        if source.source_type == "homepage" and "claims_stale" not in gap_codes:
+            score += 0.1
+        if "no_high_confidence_capabilities" not in gap_codes:
+            score += 0.15
+
+        return round(min(score, 1.0), 3)

--- a/packages/services/source_planner_agent.py
+++ b/packages/services/source_planner_agent.py
@@ -10,11 +10,13 @@ from packages.contracts.agents import AgentRunSummary, SourcePlannerRequest, Sou
 from packages.core.models import CrawlJob, Product, Source, SourceProposalDecision, Vendor
 from packages.observability.tracing import log_event, traced_span
 from packages.services.agent_run_store import AgentRunStore
+from packages.services.evidence_yield import EvidenceYieldService
+from packages.services.gap_closure import GapClosureService
 from packages.services.gap_detector import detect_product_gaps
 from packages.services.product_intelligence import ProductIntelligenceService, build_normalized_claims
 from packages.services.source_planner_ranker import ProposalHistory, SourcePlannerRanker
 
-STRATEGY_VERSION = "source_planner_v2"
+STRATEGY_VERSION = "source_planner_v3"
 _FAILED_CRAWL_STATUSES = {"failed", "retryable"}
 
 
@@ -23,6 +25,8 @@ class SourcePlannerAgentService:
         self.db = db
         self.product_intelligence = ProductIntelligenceService(db)
         self.agent_run_store = AgentRunStore(db)
+        self.evidence_yield = EvidenceYieldService(db)
+        self.gap_closure = GapClosureService(db)
         self.ranker = SourcePlannerRanker()
 
     def plan(self, request: SourcePlannerRequest) -> SourcePlannerResponse:
@@ -54,7 +58,7 @@ class SourcePlannerAgentService:
                 agent=AgentRunSummary(
                     agent_name="source_planner_agent",
                     strategy_version=STRATEGY_VERSION,
-                    mode="ranked_planner_v2",
+                    mode="ranked_planner_v3",
                 ),
                 considered_gap_codes=[gap.gap_code for gap in gaps],
                 proposals=proposals,
@@ -62,7 +66,7 @@ class SourcePlannerAgentService:
             self.agent_run_store.create_agent_run(
                 agent_name="source_planner_agent",
                 strategy_version=STRATEGY_VERSION,
-                mode="ranked_planner_v2",
+                mode="ranked_planner_v3",
                 product_id=request.product_id,
                 vendor_id=context.get("vendor_id"),
                 request_payload=request.model_dump(),
@@ -86,11 +90,11 @@ class SourcePlannerAgentService:
             "vendor_id": str(vendor.vendor_id),
         }
 
-    def _get_existing_sources(self, product_id: uuid.UUID) -> dict[str, str]:
-        rows = self.db.execute(select(Source.root_url, Source.source_type).where(Source.product_id == product_id)).all()
-        return {root_url: source_type for root_url, source_type in rows}
+    def _get_existing_sources(self, product_id: uuid.UUID) -> dict[str, tuple[str, str]]:
+        rows = self.db.execute(select(Source.root_url, Source.source_id, Source.source_type).where(Source.product_id == product_id)).all()
+        return {root_url: (str(source_id), source_type) for root_url, source_id, source_type in rows}
 
-    def _get_proposal_history(self, product_id: uuid.UUID, existing_sources: dict[str, str]) -> dict[str, ProposalHistory]:
+    def _get_proposal_history(self, product_id: uuid.UUID, existing_sources: dict[str, tuple[str, str]]) -> dict[str, ProposalHistory]:
         history_by_url: dict[str, ProposalHistory] = {}
 
         decision_rows = self.db.execute(
@@ -109,7 +113,7 @@ class SourcePlannerAgentService:
                 history.rejected_count += 1
 
         source_type_counts: dict[str, int] = {}
-        for source_type in existing_sources.values():
+        for _, source_type in existing_sources.values():
             source_type_counts[source_type] = source_type_counts.get(source_type, 0) + 1
 
         crawl_rows = self.db.execute(
@@ -125,10 +129,13 @@ class SourcePlannerAgentService:
                 history_by_url.setdefault(root_url, ProposalHistory()).recent_failed_crawls += 1
 
         for root_url, history in history_by_url.items():
-            inferred_type = existing_sources.get(root_url)
-            if inferred_type:
+            source_info = existing_sources.get(root_url)
+            if source_info:
+                source_id, inferred_type = source_info
                 history.same_type_existing_count = source_type_counts.get(inferred_type, 0)
                 history.recent_failed_crawls += crawl_failures_by_type.get(inferred_type, 0)
+                history.evidence_yield_score = self.evidence_yield.compute(source_id)
+                history.gap_closure_score = self.gap_closure.compute(product_id, source_id)
 
         return history_by_url
 
@@ -137,7 +144,7 @@ class SourcePlannerAgentService:
         *,
         primary_domain: str | None,
         gaps,
-        existing_sources: dict[str, str],
+        existing_sources: dict[str, tuple[str, str]],
         history_by_url: dict[str, ProposalHistory],
         include_existing_sources: bool,
         max_candidates: int,
@@ -156,7 +163,7 @@ class SourcePlannerAgentService:
                     proposal.target_gap_codes.append(gap_code)
                 return
             history = history_by_url.setdefault(url, ProposalHistory())
-            history.same_type_existing_count = max(history.same_type_existing_count, sum(1 for existing_type in existing_sources.values() if existing_type == source_type))
+            history.same_type_existing_count = max(history.same_type_existing_count, sum(1 for _, existing_type in existing_sources.values() if existing_type == source_type))
             candidates[url] = SourceProposal(
                 root_url=url,
                 source_type=source_type,

--- a/packages/services/source_planner_ranker.py
+++ b/packages/services/source_planner_ranker.py
@@ -22,6 +22,8 @@ class ProposalHistory:
     rejected_count: int = 0
     same_type_existing_count: int = 0
     recent_failed_crawls: int = 0
+    evidence_yield_score: float = 0.0
+    gap_closure_score: float = 0.0
 
 
 class SourcePlannerRanker:
@@ -32,6 +34,8 @@ class SourcePlannerRanker:
         score -= min(history.rejected_count * 0.12, 0.36)
         score -= min(history.same_type_existing_count * 0.05, 0.2)
         score -= min(history.recent_failed_crawls * 0.1, 0.3)
+        score += min(history.evidence_yield_score * 0.2, 0.2)
+        score += min(history.gap_closure_score * 0.2, 0.2)
         return round(score, 4)
 
     def rank(
@@ -66,6 +70,10 @@ class SourcePlannerRanker:
             parts.append("this source type already has existing coverage")
         if history.recent_failed_crawls > 0:
             parts.append("similar recent crawl attempts failed")
+        if history.evidence_yield_score > 0.0:
+            parts.append("similar promoted sources produced useful evidence")
+        if history.gap_closure_score > 0.0:
+            parts.append("similar promoted sources helped close product gaps")
 
         if not parts:
             return " Ranked using source-type prior and current evidence-gap fit."

--- a/tests/test_source_planner_ranker.py
+++ b/tests/test_source_planner_ranker.py
@@ -57,3 +57,21 @@ def test_rank_penalizes_existing_coverage_and_failed_crawls() -> None:
     assert ranked[0].root_url == cleaner.root_url
     assert "existing coverage" in ranked[1].reason.lower()
     assert "crawl attempts failed" in ranked[1].reason.lower()
+
+
+def test_rank_rewards_evidence_yield_and_gap_closure() -> None:
+    ranker = SourcePlannerRanker()
+    stronger = _proposal("https://docs.example.com", "docs_subdomain", 0.78)
+    weaker = _proposal("https://example.com/docs", "docs_path", 0.82)
+
+    ranked = ranker.rank(
+        [weaker, stronger],
+        {
+            stronger.root_url: ProposalHistory(promoted_count=1, evidence_yield_score=0.9, gap_closure_score=0.8),
+            weaker.root_url: ProposalHistory(promoted_count=1, evidence_yield_score=0.0, gap_closure_score=0.0),
+        },
+    )
+
+    assert ranked[0].root_url == stronger.root_url
+    assert "useful evidence" in ranked[0].reason.lower()
+    assert "close product gaps" in ranked[0].reason.lower()


### PR DESCRIPTION
## What this ships

Adds the first downstream usefulness signals to the source planner so ranking can learn from what actually helped after promotion.

### Included
- `packages/services/evidence_yield.py`
- `packages/services/gap_closure.py`
- `SourcePlannerRanker` upgraded with:
  - `evidence_yield_score`
  - `gap_closure_score`
- `SourcePlannerAgentService` upgraded to compute those scores for known sources and feed them into ranking
- ranking test coverage for the new reward signals

## Scope
- reward sources that produced useful evidence
- reward sources that helped close product gaps
- preserve existing signals like promotions, rejections, same-type coverage, and crawl failures
- move planner strategy/mode to v3 to reflect the new ranking logic

## Why now
This is the next major checkpoint after first-class discovery candidates. It starts teaching the planner which promoted sources were actually valuable downstream, which is the most important missing learning loop in the current system.
