### PR TITLE
PR-025: add entity resolution foundation and admin resolve surface

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -4,6 +4,7 @@ from apps.api.routes.admin import router as admin_router
 from apps.api.routes.admin_agent_ops import router as admin_agent_ops_router
 from apps.api.routes.admin_discovery import router as admin_discovery_router
 from apps.api.routes.admin_discovery_review import router as admin_discovery_review_router
+from apps.api.routes.admin_entity_resolution import router as admin_entity_resolution_router
 from apps.api.routes.admin_source_registry import router as admin_source_registry_router
 from apps.api.routes.agent_evals import router as agent_evals_router
 from apps.api.routes.agents import router as agents_router
@@ -27,6 +28,7 @@ app.include_router(admin_agent_ops_router)
 app.include_router(admin_source_registry_router)
 app.include_router(admin_discovery_router)
 app.include_router(admin_discovery_review_router)
+app.include_router(admin_entity_resolution_router)
 app.include_router(agent_evals_router)
 app.include_router(source_promotion_router)
 app.include_router(products_router)

--- a/apps/api/routes/admin_entity_resolution.py
+++ b/apps/api/routes/admin_entity_resolution.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from packages.contracts.api_common import ApiEnvelope
+from packages.contracts.entity_resolution import EntityResolutionRequest, EntityResolutionResponse
+from packages.core.deps import get_db
+from packages.services.entity_resolution import EntityResolutionService
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+@router.post("/entity-resolution/resolve", response_model=ApiEnvelope)
+def resolve_entities(payload: EntityResolutionRequest, db: Session = Depends(get_db)) -> ApiEnvelope:
+    result: EntityResolutionResponse = EntityResolutionService(db).resolve(payload)
+    return ApiEnvelope(data=result.model_dump())

--- a/packages/contracts/entity_resolution.py
+++ b/packages/contracts/entity_resolution.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, Field
+
+
+class EntityResolutionRequest(BaseModel):
+    vendor_domain: str | None = None
+    root_url: str | None = None
+    artifact_slug: str | None = None
+
+
+class VendorResolutionMatch(BaseModel):
+    vendor_id: str
+    canonical_name: str
+    canonical_slug: str
+    primary_domain: str | None = None
+    match_reason: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class ProductResolutionMatch(BaseModel):
+    product_id: str
+    canonical_name: str
+    canonical_slug: str
+    vendor_id: str
+    match_reason: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class EntityResolutionResponse(BaseModel):
+    vendor_domain: str | None = None
+    root_url: str | None = None
+    artifact_slug: str | None = None
+    vendor_matches: list[VendorResolutionMatch] = Field(default_factory=list)
+    product_matches: list[ProductResolutionMatch] = Field(default_factory=list)

--- a/packages/services/entity_resolution.py
+++ b/packages/services/entity_resolution.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from packages.contracts.entity_resolution import (
+    EntityResolutionRequest,
+    EntityResolutionResponse,
+    ProductResolutionMatch,
+    VendorResolutionMatch,
+)
+from packages.core.models import Product, Vendor
+
+
+class EntityResolutionService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def resolve(self, request: EntityResolutionRequest) -> EntityResolutionResponse:
+        vendor_matches = self._resolve_vendors(request)
+        product_matches = self._resolve_products(request, vendor_matches)
+        return EntityResolutionResponse(
+            vendor_domain=request.vendor_domain,
+            root_url=request.root_url,
+            artifact_slug=request.artifact_slug,
+            vendor_matches=vendor_matches,
+            product_matches=product_matches,
+        )
+
+    def _resolve_vendors(self, request: EntityResolutionRequest) -> list[VendorResolutionMatch]:
+        domain = self._normalize_domain(request.vendor_domain or request.root_url)
+        slug = self._normalize_slug(request.artifact_slug or domain)
+        if not domain and not slug:
+            return []
+
+        clauses = []
+        if domain:
+            clauses.append(Vendor.primary_domain == domain)
+        if slug:
+            clauses.append(Vendor.canonical_slug == slug)
+        rows = self.db.execute(select(Vendor).where(or_(*clauses))).scalars() if clauses else []
+
+        matches: list[VendorResolutionMatch] = []
+        for vendor in rows:
+            reason, confidence = self._vendor_reason_and_confidence(vendor, domain, slug)
+            matches.append(
+                VendorResolutionMatch(
+                    vendor_id=str(vendor.vendor_id),
+                    canonical_name=vendor.canonical_name,
+                    canonical_slug=vendor.canonical_slug,
+                    primary_domain=vendor.primary_domain,
+                    match_reason=reason,
+                    confidence=confidence,
+                )
+            )
+        return sorted(matches, key=lambda item: item.confidence, reverse=True)
+
+    def _resolve_products(
+        self,
+        request: EntityResolutionRequest,
+        vendor_matches: list[VendorResolutionMatch],
+    ) -> list[ProductResolutionMatch]:
+        slug = self._normalize_slug(request.artifact_slug or request.root_url or request.vendor_domain)
+        if not slug:
+            return []
+
+        vendor_ids = [match.vendor_id for match in vendor_matches]
+        stmt = select(Product)
+        if vendor_ids:
+            from uuid import UUID
+            stmt = stmt.where(Product.vendor_id.in_([UUID(vendor_id) for vendor_id in vendor_ids]))
+        stmt = stmt.where(Product.canonical_slug == slug)
+        rows = self.db.execute(stmt).scalars()
+
+        matches: list[ProductResolutionMatch] = []
+        for product in rows:
+            matches.append(
+                ProductResolutionMatch(
+                    product_id=str(product.product_id),
+                    canonical_name=product.canonical_name,
+                    canonical_slug=product.canonical_slug,
+                    vendor_id=str(product.vendor_id),
+                    match_reason="Product slug matched artifact slug within resolved vendor scope.",
+                    confidence=0.88 if vendor_ids else 0.74,
+                )
+            )
+        return matches
+
+    def _vendor_reason_and_confidence(self, vendor: Vendor, domain: str | None, slug: str | None) -> tuple[str, float]:
+        domain_match = bool(domain and vendor.primary_domain == domain)
+        slug_match = bool(slug and vendor.canonical_slug == slug)
+        if domain_match and slug_match:
+            return "Primary domain and canonical slug both matched.", 0.96
+        if domain_match:
+            return "Primary domain matched vendor domain.", 0.91
+        if slug_match:
+            return "Canonical slug matched artifact slug.", 0.78
+        return "Weak deterministic match.", 0.55
+
+    def _normalize_domain(self, value: str | None) -> str | None:
+        if not value:
+            return None
+        cleaned = value.removeprefix("https://").removeprefix("http://").split("/")[0].strip().lower()
+        if cleaned.startswith("www."):
+            cleaned = cleaned[4:]
+        return cleaned or None
+
+    def _normalize_slug(self, value: str | None) -> str | None:
+        if not value:
+            return None
+        cleaned = value.removeprefix("https://").removeprefix("http://").split("/")[0].strip().lower()
+        if cleaned.startswith("www."):
+            cleaned = cleaned[4:]
+        slug = cleaned.split(".")[0]
+        slug = slug.replace("_", "-")
+        return slug or None

--- a/packages/services/entity_resolution.py
+++ b/packages/services/entity_resolution.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
@@ -29,20 +31,20 @@ class EntityResolutionService:
 
     def _resolve_vendors(self, request: EntityResolutionRequest) -> list[VendorResolutionMatch]:
         domain = self._normalize_domain(request.vendor_domain or request.root_url)
-        slug = self._normalize_slug(request.artifact_slug or domain)
-        if not domain and not slug:
+        vendor_slug = self._derive_vendor_slug(domain)
+        if not domain and not vendor_slug:
             return []
 
         clauses = []
         if domain:
             clauses.append(Vendor.primary_domain == domain)
-        if slug:
-            clauses.append(Vendor.canonical_slug == slug)
+        if vendor_slug:
+            clauses.append(Vendor.canonical_slug == vendor_slug)
         rows = self.db.execute(select(Vendor).where(or_(*clauses))).scalars() if clauses else []
 
         matches: list[VendorResolutionMatch] = []
         for vendor in rows:
-            reason, confidence = self._vendor_reason_and_confidence(vendor, domain, slug)
+            reason, confidence = self._vendor_reason_and_confidence(vendor, domain, vendor_slug)
             matches.append(
                 VendorResolutionMatch(
                     vendor_id=str(vendor.vendor_id),
@@ -60,16 +62,14 @@ class EntityResolutionService:
         request: EntityResolutionRequest,
         vendor_matches: list[VendorResolutionMatch],
     ) -> list[ProductResolutionMatch]:
-        slug = self._normalize_slug(request.artifact_slug or request.root_url or request.vendor_domain)
+        slug = self._normalize_slug(request.artifact_slug)
         if not slug:
             return []
 
-        vendor_ids = [match.vendor_id for match in vendor_matches]
-        stmt = select(Product)
+        stmt = select(Product).where(Product.canonical_slug == slug)
+        vendor_ids = [UUID(match.vendor_id) for match in vendor_matches]
         if vendor_ids:
-            from uuid import UUID
-            stmt = stmt.where(Product.vendor_id.in_([UUID(vendor_id) for vendor_id in vendor_ids]))
-        stmt = stmt.where(Product.canonical_slug == slug)
+            stmt = stmt.where(Product.vendor_id.in_(vendor_ids))
         rows = self.db.execute(stmt).scalars()
 
         matches: list[ProductResolutionMatch] = []
@@ -94,13 +94,19 @@ class EntityResolutionService:
         if domain_match:
             return "Primary domain matched vendor domain.", 0.91
         if slug_match:
-            return "Canonical slug matched artifact slug.", 0.78
+            return "Canonical slug matched vendor slug derived from the domain.", 0.78
         return "Weak deterministic match.", 0.55
+
+    def _derive_vendor_slug(self, domain: str | None) -> str | None:
+        if not domain:
+            return None
+        return self._normalize_slug(domain)
 
     def _normalize_domain(self, value: str | None) -> str | None:
         if not value:
             return None
         cleaned = value.removeprefix("https://").removeprefix("http://").split("/")[0].strip().lower()
+        cleaned = cleaned.split(":")[0]
         if cleaned.startswith("www."):
             cleaned = cleaned[4:]
         return cleaned or None

--- a/tests/test_admin_entity_resolution_routes.py
+++ b/tests/test_admin_entity_resolution_routes.py
@@ -1,0 +1,64 @@
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from packages.core.deps import get_db
+
+
+class DummyEntityResolutionService:
+    def __init__(self, _db: object) -> None:
+        pass
+
+    def resolve(self, payload):
+        return type(
+            "Resp",
+            (),
+            {
+                "model_dump": lambda self: {
+                    "vendor_domain": payload.vendor_domain,
+                    "root_url": payload.root_url,
+                    "artifact_slug": payload.artifact_slug,
+                    "vendor_matches": [
+                        {
+                            "vendor_id": "11111111-1111-1111-1111-111111111111",
+                            "canonical_name": "Example",
+                            "canonical_slug": "example",
+                            "primary_domain": "example.com",
+                            "match_reason": "Primary domain and canonical slug both matched.",
+                            "confidence": 0.96,
+                        }
+                    ],
+                    "product_matches": [
+                        {
+                            "product_id": "22222222-2222-2222-2222-222222222222",
+                            "canonical_name": "Example Platform",
+                            "canonical_slug": "example",
+                            "vendor_id": "11111111-1111-1111-1111-111111111111",
+                            "match_reason": "Product slug matched artifact slug within resolved vendor scope.",
+                            "confidence": 0.88,
+                        }
+                    ],
+                }
+            },
+        )()
+
+
+def override_get_db():
+    yield object()
+
+
+def test_admin_entity_resolution_endpoint_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr("apps.api.routes.admin_entity_resolution.EntityResolutionService", DummyEntityResolutionService)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/admin/entity-resolution/resolve",
+        json={"vendor_domain": "example.com", "artifact_slug": "example"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["vendor_matches"][0]["canonical_slug"] == "example"
+    assert body["product_matches"][0]["canonical_name"] == "Example Platform"
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## What this ships

Adds the first deterministic entity-resolution layer for vendors and products.

### Included
- `packages/contracts/entity_resolution.py`
- `packages/services/entity_resolution.py`
- `apps/api/routes/admin_entity_resolution.py`
- app wiring for `POST /v1/admin/entity-resolution/resolve`
- dedicated route coverage

## Scope
- deterministically resolve vendor matches using primary domain and canonical slug
- deterministically resolve product matches using artifact slug within resolved vendor scope
- return structured match reasons and confidence scores
- expose entity resolution through a narrow admin utility surface

## Why now
This is the next major checkpoint after discovery workflow objects and planner feedback signals. It creates the foundation BMT needs to widen discovery without letting public-data noise fragment into duplicate vendor/product identities.
